### PR TITLE
Add initial router, cart and backend scaffold

### DIFF
--- a/tobis-space/.env.example
+++ b/tobis-space/.env.example
@@ -1,0 +1,1 @@
+STRIPE_SECRET=sk_test_your_secret

--- a/tobis-space/package.json
+++ b/tobis-space/package.json
@@ -7,11 +7,16 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
+    "express": "^4.19.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.0",
+    "stripe": "^14.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/tobis-space/server/index.js
+++ b/tobis-space/server/index.js
@@ -1,0 +1,27 @@
+import express from 'express'
+import Stripe from 'stripe'
+import dotenv from 'dotenv'
+
+dotenv.config()
+
+const app = express()
+app.use(express.json())
+
+const stripe = new Stripe(process.env.STRIPE_SECRET || '', { apiVersion: '2024-08-16' })
+
+app.post('/create-checkout-session', async (req, res) => {
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: req.body.items,
+      success_url: `${req.headers.origin}/success`,
+      cancel_url: `${req.headers.origin}/cancel`,
+    })
+    res.json({ url: session.url })
+  } catch (err) {
+    res.status(500).json({ error: 'Unable to create session' })
+  }
+})
+
+const port = process.env.PORT || 3001
+app.listen(port, () => console.log(`Server running on ${port}`))

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -1,23 +1,25 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Route, Routes } from 'react-router-dom'
+import Layout from './components/Layout'
+import Home from './pages/Home'
+import BoardGame from './pages/BoardGame'
+import Stories from './pages/Stories'
+import Drawings from './pages/Drawings'
+import CheckoutSuccess from './pages/CheckoutSuccess'
+import CheckoutCancel from './pages/CheckoutCancel'
+import Cart from './components/Cart'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-       
-      </div>
-      
-          <h1 className="text-3xl font-bold underline">
-      Hello world!
-    </h1>
-
-    </>
+    <Routes>
+      <Route path="/" element={<Layout />}>
+        <Route index element={<Home />} />
+        <Route path="boardgame" element={<BoardGame />} />
+        <Route path="stories" element={<Stories />} />
+        <Route path="drawings" element={<Drawings />} />
+        <Route path="cart" element={<Cart />} />
+        <Route path="success" element={<CheckoutSuccess />} />
+        <Route path="cancel" element={<CheckoutCancel />} />
+      </Route>
+    </Routes>
   )
 }
-
-export default App

--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -1,0 +1,29 @@
+import { useCart } from '../contexts/CartContext'
+
+export default function Cart() {
+  const { items, removeItem, clear } = useCart()
+
+  if (items.length === 0) return <p>Your cart is empty.</p>
+
+  return (
+    <div className="p-4 border rounded bg-gray-100">
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="flex justify-between">
+            <span>{item.name}</span>
+            <span>{item.price.toFixed(2)} €</span>
+            <button onClick={() => removeItem(item.id)}>X</button>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-4 flex justify-between">
+        <strong>
+          Total {items.reduce((sum, i) => sum + i.price, 0).toFixed(2)} €
+        </strong>
+        <button onClick={clear} className="ml-2 text-sm text-red-500">
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -1,0 +1,30 @@
+import { NavLink } from 'react-router-dom'
+import { useCart } from '../contexts/CartContext'
+
+export default function Header() {
+  const { items } = useCart()
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    isActive ? 'text-blue-500' : 'text-gray-700'
+
+  return (
+    <header className="p-4 border-b flex justify-between items-center">
+      <nav className="space-x-4">
+        <NavLink to="/" className={linkClass} end>
+          Home
+        </NavLink>
+        <NavLink to="/boardgame" className={linkClass}>
+          Board Game
+        </NavLink>
+        <NavLink to="/stories" className={linkClass}>
+          Stories
+        </NavLink>
+        <NavLink to="/drawings" className={linkClass}>
+          Drawings
+        </NavLink>
+      </nav>
+      <NavLink to="/cart" className="relative" aria-label="Cart">
+        Cart ({items.length})
+      </NavLink>
+    </header>
+  )
+}

--- a/tobis-space/src/components/Layout.tsx
+++ b/tobis-space/src/components/Layout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom'
+import Header from './Header'
+
+export default function Layout() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+      <main className="flex-1 p-4">
+        <Outlet />
+      </main>
+      <footer className="p-4 border-t text-center">&copy; 2024 Tobis Space</footer>
+    </div>
+  )
+}

--- a/tobis-space/src/contexts/CartContext.tsx
+++ b/tobis-space/src/contexts/CartContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+export interface CartItem {
+  id: string
+  name: string
+  price: number
+}
+
+interface CartContextValue {
+  items: CartItem[]
+  addItem: (item: CartItem) => void
+  removeItem: (id: string) => void
+  clear: () => void
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined)
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([])
+
+  const addItem = (item: CartItem) => setItems((prev) => [...prev, item])
+  const removeItem = (id: string) =>
+    setItems((prev) => prev.filter((i) => i.id !== id))
+  const clear = () => setItems([])
+
+  return (
+    <CartContext.Provider value={{ items, addItem, removeItem, clear }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext)
+  if (!ctx) throw new Error('useCart must be used within CartProvider')
+  return ctx
+}

--- a/tobis-space/src/main.tsx
+++ b/tobis-space/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { CartProvider } from './contexts/CartContext'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
+    <BrowserRouter>
+      <CartProvider>
+        <App />
+      </CartProvider>
+    </BrowserRouter>
+  </StrictMode>
 )

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -1,0 +1,19 @@
+import { useCart } from '../contexts/CartContext'
+
+export default function BoardGame() {
+  const { addItem } = useCart()
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl">Board Game</h2>
+      <button
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() =>
+          addItem({ id: 'boardgame', name: 'Awesome Board Game', price: 29.99 })
+        }
+      >
+        Add to Cart
+      </button>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/CheckoutCancel.tsx
+++ b/tobis-space/src/pages/CheckoutCancel.tsx
@@ -1,0 +1,3 @@
+export default function CheckoutCancel() {
+  return <h2 className="text-xl">Checkout canceled.</h2>
+}

--- a/tobis-space/src/pages/CheckoutSuccess.tsx
+++ b/tobis-space/src/pages/CheckoutSuccess.tsx
@@ -1,0 +1,3 @@
+export default function CheckoutSuccess() {
+  return <h2 className="text-xl">Thank you for your purchase!</h2>
+}

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,0 +1,30 @@
+import { useCart } from '../contexts/CartContext'
+
+const artworks = [
+  { id: 'drawing1', name: 'Drawing 1', price: 9.99 },
+  { id: 'drawing2', name: 'Drawing 2', price: 9.99 },
+]
+
+export default function Drawings() {
+  const { addItem } = useCart()
+
+  return (
+    <div>
+      <h2 className="text-xl mb-4">Drawings</h2>
+      <div className="grid grid-cols-2 gap-4">
+        {artworks.map((art) => (
+          <div key={art.id} className="border p-2">
+            <div className="h-24 bg-gray-200 mb-2" />
+            <p>{art.name}</p>
+            <button
+              className="mt-2 px-2 py-1 bg-blue-500 text-white rounded"
+              onClick={() => addItem(art)}
+            >
+              Add to Cart
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h2 className="text-xl">Welcome to Tobi's Space</h2>
+}

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,0 +1,19 @@
+import { useCart } from '../contexts/CartContext'
+
+export default function Stories() {
+  const { addItem } = useCart()
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl">Stories</h2>
+      <button
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() =>
+          addItem({ id: 'story', name: 'Great Story', price: 4.99 })
+        }
+      >
+        Add to Cart
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- set up React Router with shared layout and pages
- add Cart context and simple cart UI
- show cart link and counter in header
- add Express server skeleton with Stripe checkout endpoint
- provide .env.example for Stripe secret

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_685b84c755848323ac106aacfda963a1