### PR TITLE
Implement cart drawer and artwork preview modal

### DIFF
--- a/Task.md
+++ b/Task.md
@@ -13,35 +13,35 @@ A personal homepage with subpages for:
 ## ✅ Frontend Setup
 - [x] Scaffold frontend using **Vite + React + Tailwind (TypeScript + SWC)**
 - [x] Configure Tailwind with working `tailwind.config.ts` and global styles
-- [ ] Set up **basic layout**: header, nav bar, footer
-- [ ] Install and configure **React Router v6+** for subpages
+- [x] Set up **basic layout**: header, nav bar, footer
+- [x] Install and configure **React Router v6+** for subpages
 
 ## 🧭 Pages & Navigation
-- [ ] Create routes:
+- [x] Create routes:
   - `/` → Homepage
   - `/boardgame` → Board Game section
   - `/stories` → Stories section
   - `/drawings` → Painted Drawings (virtual gallery)
-- [ ] Add navigation bar with active link highlighting
-- [ ] Implement a **shared layout** (e.g. with `<Outlet>`)
+- [x] Add navigation bar with active link highlighting
+- [x] Implement a **shared layout** (e.g. with `<Outlet>`)
 
 ## 🛒 Cart & Product Display
-- [ ] Implement global **Cart Context** using React Context API or signals
-- [ ] Show cart icon in header with item count
-- [ ] Enable **Add to Cart** functionality from each subpage
-- [ ] Create a **Cart drawer or modal** to show items and total
+- [x] Implement global **Cart Context** using React Context API or signals
+- [x] Show cart icon in header with item count
+- [x] Enable **Add to Cart** functionality from each subpage
+- [x] Create a **Cart drawer or modal** to show items and total
 
 ## 🎨 Drawings Gallery (Virtual Room)
-- [ ] Display paintings in a **virtual gallery style UI**
-- [ ] Add modal to preview enlarged artwork
-- [ ] Allow adding individual artworks to cart
+- [x] Display paintings in a **virtual gallery style UI**
+- [x] Add modal to preview enlarged artwork
+- [x] Allow adding individual artworks to cart
 - [ ] (Later) Add hover effects or simple 3D illusion
 
 ## 💳 Stripe Checkout Integration
-- [ ] Set up basic **Node.js Express backend**
-- [ ] Implement `/create-checkout-session` endpoint
-- [ ] Redirect user to Stripe Checkout when clicking "Buy"
-- [ ] Handle success/cancel URLs (e.g. `/success`, `/cancel`)
+- [x] Set up basic **Node.js Express backend**
+- [x] Implement `/create-checkout-session` endpoint
+- [x] Redirect user to Stripe Checkout when clicking "Buy"
+- [x] Handle success/cancel URLs (e.g. `/success`, `/cancel`)
 - [ ] (Optional) Add webhook handling for digital delivery
 
 ## 📦 Backend Hosting

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -6,7 +6,6 @@ import Stories from './pages/Stories'
 import Drawings from './pages/Drawings'
 import CheckoutSuccess from './pages/CheckoutSuccess'
 import CheckoutCancel from './pages/CheckoutCancel'
-import Cart from './components/Cart'
 
 export default function App() {
   return (
@@ -16,7 +15,6 @@ export default function App() {
         <Route path="boardgame" element={<BoardGame />} />
         <Route path="stories" element={<Stories />} />
         <Route path="drawings" element={<Drawings />} />
-        <Route path="cart" element={<Cart />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />
       </Route>

--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -1,4 +1,16 @@
-import { useCart } from '../contexts/CartContext'
+import { useCart, CartItem } from '../contexts/CartContext'
+
+async function checkout(items: CartItem[]) {
+  const res = await fetch('/create-checkout-session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items }),
+  })
+  const data = await res.json()
+  if (data.url) {
+    window.location.href = data.url
+  }
+}
 
 export default function Cart() {
   const { items, removeItem, clear } = useCart()
@@ -16,12 +28,20 @@ export default function Cart() {
           </li>
         ))}
       </ul>
-      <div className="mt-4 flex justify-between">
-        <strong>
-          Total {items.reduce((sum, i) => sum + i.price, 0).toFixed(2)} €
-        </strong>
-        <button onClick={clear} className="ml-2 text-sm text-red-500">
-          Clear
+      <div className="mt-4 flex flex-col space-y-2">
+        <div className="flex justify-between">
+          <strong>
+            Total {items.reduce((sum, i) => sum + i.price, 0).toFixed(2)} €
+          </strong>
+          <button onClick={clear} className="ml-2 text-sm text-red-500">
+            Clear
+          </button>
+        </div>
+        <button
+          onClick={() => checkout(items)}
+          className="px-4 py-2 bg-green-500 text-white rounded"
+        >
+          Buy
         </button>
       </div>
     </div>

--- a/tobis-space/src/components/CartDrawer.tsx
+++ b/tobis-space/src/components/CartDrawer.tsx
@@ -1,0 +1,14 @@
+import Cart from './Cart'
+
+export default function CartDrawer({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex justify-end z-50">
+      <div className="bg-white text-black w-80 h-full p-4 shadow-xl overflow-y-auto">
+        <button className="mb-2" onClick={onClose}>
+          Close
+        </button>
+        <Cart />
+      </div>
+    </div>
+  )
+}

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -1,7 +1,11 @@
 import { NavLink } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
 
-export default function Header() {
+export default function Header({
+  openCart,
+}: {
+  openCart: () => void
+}) {
   const { items } = useCart()
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     isActive ? 'text-blue-500' : 'text-gray-700'
@@ -22,9 +26,9 @@ export default function Header() {
           Drawings
         </NavLink>
       </nav>
-      <NavLink to="/cart" className="relative" aria-label="Cart">
+      <button onClick={openCart} className="relative" aria-label="Cart">
         Cart ({items.length})
-      </NavLink>
+      </button>
     </header>
   )
 }

--- a/tobis-space/src/components/Layout.tsx
+++ b/tobis-space/src/components/Layout.tsx
@@ -1,14 +1,19 @@
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
+import CartDrawer from './CartDrawer'
 
 export default function Layout() {
+  const [cartOpen, setCartOpen] = useState(false)
+
   return (
     <div className="min-h-screen flex flex-col">
-      <Header />
+      <Header openCart={() => setCartOpen(true)} />
       <main className="flex-1 p-4">
         <Outlet />
       </main>
       <footer className="p-4 border-t text-center">&copy; 2024 Tobis Space</footer>
+      {cartOpen && <CartDrawer onClose={() => setCartOpen(false)} />}
     </div>
   )
 }

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useCart } from '../contexts/CartContext'
 
 const artworks = [
@@ -7,6 +8,7 @@ const artworks = [
 
 export default function Drawings() {
   const { addItem } = useCart()
+  const [selected, setSelected] = useState<typeof artworks[0] | null>(null)
 
   return (
     <div>
@@ -14,7 +16,10 @@ export default function Drawings() {
       <div className="grid grid-cols-2 gap-4">
         {artworks.map((art) => (
           <div key={art.id} className="border p-2">
-            <div className="h-24 bg-gray-200 mb-2" />
+            <div
+              className="h-24 bg-gray-200 mb-2 cursor-pointer"
+              onClick={() => setSelected(art)}
+            />
             <p>{art.name}</p>
             <button
               className="mt-2 px-2 py-1 bg-blue-500 text-white rounded"
@@ -25,6 +30,23 @@ export default function Drawings() {
           </div>
         ))}
       </div>
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white text-black p-4">
+            <div className="h-48 w-48 bg-gray-200 mb-2" />
+            <p className="mb-2">{selected.name}</p>
+            <button
+              className="px-4 py-2 bg-blue-500 text-white rounded"
+              onClick={() => addItem(selected)}
+            >
+              Add to Cart
+            </button>
+            <button className="ml-2" onClick={() => setSelected(null)}>
+              Close
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add Cart drawer triggered from header
- allow checkout via Stripe and open session
- preview drawings in a modal and add to cart
- update tasks with completed items

## Testing
- `npm run build` *(fails: Could not find module 'react/jsx-runtime' and other type declarations)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685b89c082308323bc7a41934341b83c