### PR TITLE
Add responsive hero section and layout tweaks

### DIFF
--- a/Task.md
+++ b/Task.md
@@ -53,3 +53,7 @@ A personal homepage with subpages for:
 - [ ] Deploy frontend (Vite) to GitHub Pages or Vercel
 - [ ] Connect to backend Stripe API from frontend
 - [ ] Use custom domain (optional)
+
+## 🎨 Design Enhancements
+- [x] Improve layout with Tailwind so pages fill the screen and respond well on mobile
+- [x] Add a full-screen hero section on the homepage

--- a/tobis-space/src/components/CartDrawer.tsx
+++ b/tobis-space/src/components/CartDrawer.tsx
@@ -3,7 +3,7 @@ import Cart from './Cart'
 export default function CartDrawer({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 bg-black/50 flex justify-end z-50">
-      <div className="bg-white text-black w-80 h-full p-4 shadow-xl overflow-y-auto">
+      <div className="bg-white text-black h-full w-full max-w-xs sm:w-80 p-4 shadow-xl overflow-y-auto">
         <button className="mb-2" onClick={onClose}>
           Close
         </button>

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -11,24 +11,26 @@ export default function Header({
     isActive ? 'text-blue-500' : 'text-gray-700'
 
   return (
-    <header className="p-4 border-b flex justify-between items-center">
-      <nav className="space-x-4">
-        <NavLink to="/" className={linkClass} end>
-          Home
-        </NavLink>
-        <NavLink to="/boardgame" className={linkClass}>
-          Board Game
-        </NavLink>
-        <NavLink to="/stories" className={linkClass}>
-          Stories
-        </NavLink>
-        <NavLink to="/drawings" className={linkClass}>
-          Drawings
-        </NavLink>
-      </nav>
-      <button onClick={openCart} className="relative" aria-label="Cart">
-        Cart ({items.length})
-      </button>
+    <header className="p-4 border-b">
+      <div className="container mx-auto flex justify-between items-center">
+        <nav className="flex gap-4">
+          <NavLink to="/" className={linkClass} end>
+            Home
+          </NavLink>
+          <NavLink to="/boardgame" className={linkClass}>
+            Board Game
+          </NavLink>
+          <NavLink to="/stories" className={linkClass}>
+            Stories
+          </NavLink>
+          <NavLink to="/drawings" className={linkClass}>
+            Drawings
+          </NavLink>
+        </nav>
+        <button onClick={openCart} className="relative" aria-label="Cart">
+          Cart ({items.length})
+        </button>
+      </div>
     </header>
   )
 }

--- a/tobis-space/src/components/Layout.tsx
+++ b/tobis-space/src/components/Layout.tsx
@@ -9,7 +9,7 @@ export default function Layout() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header openCart={() => setCartOpen(true)} />
-      <main className="flex-1 p-4">
+      <main className="flex-1 p-4 container mx-auto w-full">
         <Outlet />
       </main>
       <footer className="p-4 border-t text-center">&copy; 2024 Tobis Space</footer>

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,3 +1,7 @@
 export default function Home() {
-  return <h2 className="text-xl">Welcome to Tobi's Space</h2>
+  return (
+    <section className="h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-indigo-700 text-white text-center">
+      <h1 className="text-4xl sm:text-6xl font-bold">Welcome to Tobi's Space</h1>
+    </section>
+  )
 }


### PR DESCRIPTION
## Summary
- update Task list with a new Design Enhancements section
- tweak Layout component and Header to use responsive containers
- adjust CartDrawer width for small screens
- implement a full-screen hero section on the Home page

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c2267deb4832381b1f1d01d9fdd59