### PR TITLE
Add board game subpages

### DIFF
--- a/Task.md
+++ b/Task.md
@@ -57,3 +57,7 @@ A personal homepage with subpages for:
 ## 🎨 Design Enhancements
 - [x] Improve layout with Tailwind so pages fill the screen and respond well on mobile
 - [x] Add a full-screen hero section on the homepage
+
+## ℹ️ File Locations
+- **Board Game page component**: `tobis-space/src/pages/BoardGame.tsx`
+- **Board Game subpages**: `tobis-space/src/pages/BoardGameCommunity.tsx`, `tobis-space/src/pages/BoardGameRules.tsx`

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -2,6 +2,8 @@ import { Route, Routes } from 'react-router-dom'
 import Layout from './components/Layout'
 import Home from './pages/Home'
 import BoardGame from './pages/BoardGame'
+import BoardGameCommunity from './pages/BoardGameCommunity'
+import BoardGameRules from './pages/BoardGameRules'
 import Stories from './pages/Stories'
 import Drawings from './pages/Drawings'
 import CheckoutSuccess from './pages/CheckoutSuccess'
@@ -12,7 +14,10 @@ export default function App() {
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<Home />} />
-        <Route path="boardgame" element={<BoardGame />} />
+        <Route path="boardgame" element={<BoardGame />}>
+          <Route path="community" element={<BoardGameCommunity />} />
+          <Route path="rules" element={<BoardGameRules />} />
+        </Route>
         <Route path="stories" element={<Stories />} />
         <Route path="drawings" element={<Drawings />} />
         <Route path="success" element={<CheckoutSuccess />} />

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -1,3 +1,4 @@
+import { Link, Outlet } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
 
 export default function BoardGame() {
@@ -6,6 +7,14 @@ export default function BoardGame() {
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Board Game</h2>
+      <nav className="flex gap-4">
+        <Link to="rules" className="text-blue-500 underline">
+          Rules
+        </Link>
+        <Link to="community" className="text-blue-500 underline">
+          Community
+        </Link>
+      </nav>
       <button
         className="px-4 py-2 bg-blue-500 text-white rounded"
         onClick={() =>
@@ -14,6 +23,7 @@ export default function BoardGame() {
       >
         Add to Cart
       </button>
+      <Outlet />
     </div>
   )
 }

--- a/tobis-space/src/pages/BoardGameCommunity.tsx
+++ b/tobis-space/src/pages/BoardGameCommunity.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export default function BoardGameCommunity() {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold">Community Links</h3>
+      <ul className="list-disc list-inside">
+        <li>
+          <a href="https://discord.gg" target="_blank" rel="noreferrer" className="text-blue-500 underline">Discord</a>
+        </li>
+        <li>
+          <a href="https://www.instagram.com/dragonsboardgames/" target="_blank" rel="noreferrer" className="text-blue-500 underline">Instagram</a>
+        </li>
+        <li>
+          <a href="https://boardgamegeek.com" target="_blank" rel="noreferrer" className="text-blue-500 underline">BoardGameGeek</a>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function BoardGameRules() {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold">Rules Overview</h3>
+      <p>Here you can provide a summary of the game rules.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- list board game page locations in `Task.md`
- add a community subpage with links
- add a rules subpage
- link new subpages from the board game page
- configure nested routes for the new pages

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c440986e08323994120eeec2053ad