### PR TITLE
Add chapter navigation and markdown reader

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -54,6 +54,7 @@ Build a personal homepage where visitors can browse board games, read stories, a
 - **Pages & Navigation**: Implement routes for the homepage, board game, stories, and drawings with a shared layout.
 - **Cart & Product Display**: Global cart context, add-to-cart buttons, and a drawer/modal to show items.
 - **Content Sections**: Board game showcase, stories list with full texts, and a virtual drawings gallery with image modal.
+- **Chapter Navigation**: Stories load chapters from Markdown files with corresponding images.
 - **Stripe Checkout**: Node.js backend exposes `/create-checkout-session` and handles success/cancel redirects.
 - **Deployment**: Host frontend and backend (e.g., Vercel/Render) and store Stripe secrets as environment variables.
 - **Design Enhancements**: Responsive layout using Tailwind and a full-screen hero section.

--- a/Agent/frontend/stories.md
+++ b/Agent/frontend/stories.md
@@ -7,6 +7,8 @@
 
 ## The Summoners' Veiled Cards
 
-- Chapters stored in [`Agent/stories/`](../stories) as Markdown files
-- Sample chapter: [chapter-1.md](../stories/chapter-1.md)
+- Chapters stored in `tobis-space/src/chapters/chapter-files` as Markdown files
+- Images for each chapter in `tobis-space/src/chapters/images`
+- Story page lists chapters and links to `/stories/:chapterSlug`
+- Clicking a chapter shows its text and image
 - Original story on [Wattpad](https://www.wattpad.com/1528766096-the-summoners%27-veiled-cards-chapter-1-the-fire-in)

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -6,6 +6,7 @@ import BoardGameCommunity from './pages/BoardGameCommunity'
 import BoardGameRules from './pages/BoardGameRules'
 import BoardGameUpdates from './pages/BoardGameUpdates'
 import Stories from './pages/Stories'
+import Chapter from './pages/Chapter'
 import Drawings from './pages/Drawings'
 import CheckoutSuccess from './pages/CheckoutSuccess'
 import CheckoutCancel from './pages/CheckoutCancel'
@@ -20,7 +21,9 @@ export default function App() {
           <Route path="rules" element={<BoardGameRules />} />
           <Route path="updates" element={<BoardGameUpdates />} />
         </Route>
-        <Route path="stories" element={<Stories />} />
+        <Route path="stories" element={<Stories />}>
+          <Route path=":chapterSlug" element={<Chapter />} />
+        </Route>
         <Route path="drawings" element={<Drawings />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />

--- a/tobis-space/src/chapters/index.ts
+++ b/tobis-space/src/chapters/index.ts
@@ -1,0 +1,39 @@
+const chapterModules = import.meta.glob('./chapter-files/*.md', { as: 'raw', eager: true })
+const imageModules = import.meta.glob('./images/*.{png,jpg,jpeg}', {
+  eager: true,
+  import: 'default',
+})
+
+export interface Chapter {
+  number: number
+  slug: string
+  title: string
+  content: string
+  image?: string
+}
+
+function extractNumber(fileName: string): number {
+  const match = fileName.match(/Chapter[_\s-]*(\d+)/i)
+  return match ? parseInt(match[1]) : 0
+}
+
+const chapters: Chapter[] = Object.entries(chapterModules).map(([path, content]) => {
+  const fileName = path.split('/').pop() ?? ''
+  const number = extractNumber(fileName)
+  const slug = `chapter-${number}`
+  const firstLine = (content as string).split('\n')[0]
+  const title = firstLine.replace(/[*#]/g, '').trim()
+
+  let image: string | undefined
+  for (const [imgPath, url] of Object.entries(imageModules)) {
+    const imgName = imgPath.split('/').pop() ?? ''
+    if (extractNumber(imgName) === number) {
+      image = url as string
+      break
+    }
+  }
+
+  return { number, slug, title, content: content as string, image }
+}).sort((a, b) => a.number - b.number)
+
+export default chapters

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -1,0 +1,17 @@
+import { useParams } from "react-router-dom"
+import chapters from "../chapters"
+
+export default function Chapter() {
+  const { chapterSlug } = useParams()
+  const chapter = chapters.find((c) => c.slug === chapterSlug)
+  if (!chapter) return <div>Chapter not found</div>
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-bold">{chapter.title}</h3>
+      {chapter.image && (
+        <img src={chapter.image} alt={chapter.title} className="max-w-full" />
+      )}
+      <pre className="whitespace-pre-wrap">{chapter.content}</pre>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,3 +1,5 @@
+import { Link, Outlet } from 'react-router-dom'
+import chapters from '../chapters'
 import { useCart } from '../contexts/CartContext'
 
 export default function Stories() {
@@ -6,14 +8,20 @@ export default function Stories() {
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Stories</h2>
+      <nav className="flex flex-wrap gap-2">
+        {chapters.map((ch) => (
+          <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
+            {ch.title}
+          </Link>
+        ))}
+      </nav>
       <button
         className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() =>
-          addItem({ id: 'story', name: 'Great Story', price: 4.99 })
-        }
+        onClick={() => addItem({ id: 'story', name: 'Great Story', price: 4.99 })}
       >
         Add to Cart
       </button>
+      <Outlet />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- support chapter navigation in stories section
- display markdown chapters with optional images
- document chapter folder location in agent instructions

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a7857fc83239865a84802859c0b