### PR TITLE
Add board game rules markdown

### DIFF
--- a/Agent/frontend/boardgame.md
+++ b/Agent/frontend/boardgame.md
@@ -3,5 +3,6 @@
 - [x] Build a dedicated page with screenshots and descriptions
 - [x] Allow adding the board game product to the cart
 - [ ] Offer downloadable rulebook PDF
+- [x] Load rules from Markdown file on the Rules page
 - [ ] (Optional) Include player testimonials or reviews
 - [ ] Add **Updates** subpage to display changelog entries

--- a/tobis-space/src/boardgame/manual/dragon-boardgame-rules.md
+++ b/tobis-space/src/boardgame/manual/dragon-boardgame-rules.md
@@ -1,0 +1,120 @@
+# 🐉 Drachen-Brettspiel – Anleitung
+
+## 📦 Aufbau
+- 🧩 **Spielbrett – Hexagons**
+  - 🏰 Lege das farbige Schloss des **Drachenherrschers** (mit Drachen-Symbol) in die Mitte des Tisches.
+  - 🔷 Platziere **18 Hexagons** zufällig um das Schloss als größeres Sechseck:
+    - 🔵 3x Blau (mit blauem Drachenei)
+    - 🟢 3x Grün (mit grünem Drachenei)
+    - 🔴 3x Rot (mit rotem Drachenei)
+    - 🌀 3x Portale
+    - 🌈 3x Farbwechsel (Pfeil mit farbigem Hintergrund)
+    - 👣 3x Bewegung (Fußabdruck-Symbol)
+  - 🧍 Jeder Spieler erhält ein Schloss-Hex in seiner Farbe.
+- 🪙 **Münz-Tokens**
+  - 🐉 Lege den Drachenherrscher-Token mit der Zahl **16** in die Mitte.
+  - Platziere Drachentokens zufällig von innen nach außen:
+    - Innen: viereckige **8er** Tokens (Gold)
+    - Mitte: viereckige **4er** Tokens (Silber)
+    - Außen: viereckige **2er** Tokens (Bronze)
+- 🃏 **Karten**
+  - 🎨 Mische die Farbkarten (bunte Rückseite) und lege sie verdeckt an den Rand.
+  - Erstelle **3 Drachenkarten-Stapel** und lege diese daneben:
+    - Kein Ei auf der Rückseite
+    - 🥚🥚 2 Eier
+    - 🥚🥚🥚🥚🥚 5 Eier
+  - Drehe die oberste Karte jedes Stapels um und lege sie offen daneben.
+
+## 🧑‍🤝‍🧑 Spielvorbereitung – Jeder Spieler erhält
+- 🗡️ 1 Startkarte
+- 📋 1 Zuginfokarte / Sammelinfo
+- 🃏 5 Start-Drachenkarten (ohne Ei auf Rückseite)
+- 🐲 2 Drachen-Spielsteine in Spielerfarbe
+- 🏰 1 Schloss-Hex
+- 🟢🔵🔴 je 1 grünes, blaues & rotes Drachenmepple
+- 👣 4 Bewegungstokens
+
+## 🚀 Spielstart
+- 🔁 **Erste Runde** – beginnt im Gegenuhrzeigersinn.
+- Am Beginn seines ersten Zugs darf jeder Spieler:
+  - 🏰 seine Startburg auf dem Spielfeld platzieren
+  - 🐲 seine 2 Drachen auf der Burg platzieren
+- 👉 Danach die erste Farbanzeigekarte aufdecken – diese bestimmt die aktive Farbe für Kämpfe und bunte Tokens.
+- Weitere Runden folgen im Uhrzeigersinn, der letzte Spieler ist der erste Spieler der 2. Runde.
+
+## 🔄 Zugübersicht – Mögliche Aktionen
+Ein Spieler darf beliebig kombinieren:
+- 🐾 Drachenspielstein bewegen
+- 🃏 Karte ziehen
+- 🐉 Karte ausspielen (Kosten bezahlen)
+- ❌ Karte abwerfen (nur am Ende des Zuges)
+- 🥚 Drachenei sammeln
+
+## ⚙️ Details zu Aktionen
+### 🐾 Spielstein bewegen
+Bewege dich über **weiße Linien** oder bei deinem Schloss auch über farbige Linien.
+Spezialfelder:
+- 👣 Bewegungshexagon = +1 zusätzliche Aktion (max 1× pro Hexagon)
+- 🌀 Portal = Teleport zu einem beliebigen anderen Portal
+- 🌈 Farbwechsel = gib eine Aktion aus, um die nächste Farbkarte aufzudecken (max 1× pro Zug)
+
+### 🪙 Münztoken aufnehmen
+Händler geben dir eine besondere Belohnung für die Stärke deiner Drachenarmee.
+- 🔵🟢🔴 Farbige Münztokens: Nur wenn deine **Drachenleben** in dieser Farbe ≥ Zahlenwert
+- 🌈 Bunte Tokens: Nur wenn du genug Drachenleben in der **aktuellen Anzeigefarbe** hast (Anzeigefarbe ≥ Zahlenwert)
+- ⚠️ Nicht aufnehmbar in Friedensrunden
+
+### 👑 Drachenherrscher besiegen
+Funktioniert wie bei farbigem Münztoken – benötige gleich oder mehr Drachenleben in der Anzeigefarbe. Angriff nicht möglich in der Friedensrunde.
+
+### ⚔️ Kampf mit Gegner
+- ☮️ Friedliche Runde: Du darfst keinen Gegner angreifen oder betreten. Auch können keine bunten Münztokens aufgenommen werden.
+- 🎯 Ist ein Gegner im Weg und Kampf erlaubt:
+  - Führe alle zulässigen Kampfaktionen aus
+  - Vergleiche Lebenstoken in der Anzeigefarbe
+  - Gewinner = Spieler mit mehr Leben
+  - Gleichstand? → Neue Farbanzeigekarte → zweiter Vergleich
+  - Noch Gleichstand? Beide bleiben stehen
+  - Wenn Farbe oder Leben sich später ändern → neuer Vergleich.
+- 🏁 Nach dem Kampf:
+  - Verlierer = Spielstein zurück ins Schloss
+  - Neue Farbanzeigekarte aufdecken
+  - Beide Spieler erhalten 1 Lebenstoken in der Anzeigefarbe
+
+### 🥚 Drachenei sammeln
+- Mitten eines Dracheneier-Hexagons betreten
+- Pro Drachenspielstein einmal pro Runde 1 Ei pro betretenem Dracheneier-Hexagon
+- Jederzeit im Zug nutzbar
+
+### 🃏 Karten ziehen
+Ziehe von einem der 3 verdeckten Drachenstapel oder von den offenen Kartenstapel bis maximal fünf Handkarten.
+- 📌 Jedes Mal, wenn man Karten aufnimmt, kostet dies 1 Aktion (für bis max 5 Handkarten)
+- Beispiel: Zieht man 3 Karten, bewegt den Drachen, sammelt ein Ei, spielt eine aus und möchte dann wieder Karten ziehen, kostet dies 2× eine Aktion.
+
+### 🐉 Karten ausspielen
+Bezahle Aktions- und Eierkosten mit eigenen Eiern oder gelegten 🐲 Drachen (Wert = Ei-Kosten).
+- Verwendete Drachenkarten werden offen neben die drei Drachenstapel gelegt (es bilden sich dadurch drei neue offene Stapel).
+- Maximal 5 Karten dürfen aktiv sein.
+- Sammelbonus darf durch Drachenlebentoken angezeigt werden.
+
+### ❌ Karten abwerfen
+- Kostenlos und nur am Ende des Zuges erlaubt.
+- Abgelegte Karten auf einen beliebigen der drei offenen Stapel legen.
+- Ausnahme: Wenn ein offener Stapel nicht vorhanden ist, **musst** du diesen auffüllen.
+
+## 🏆 Spielziel
+Besiege den 🐉 Drachenherrscher (16), indem du genug Drachenleben in der Anzeigefarbe hast und den Kampf gewinnst.
+
+## Spielmodus
+Spielt alle gegen alle oder 2 gegen 2.
+
+### Mit mehr als 4 Spielern
+Erweitere das hexagonale Spielfeld mit:
+- Pro weiterer Spieler:
+  - 🔵 1x Blau (mit blauem Drachenei)
+  - 🟢 1x Grün (mit grünem Drachenei)
+  - 🔴 1x Rot (mit rotem Drachenei)
+- Pro zwei weitere Spieler:
+  - 🌀 1x Portale
+  - 🌈 1x Farbwechsel (Pfeil mit farbigem Hintergrund)
+  - 👣 1x Bewegung (Fußabdruck-Symbol)

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React from "react"
+import rulesText from "../boardgame/manual/dragon-boardgame-rules.md?raw"
 
 export default function BoardGameRules() {
   return (
-    <div className="space-y-2">
-      <h3 className="text-lg font-semibold">Rules Overview</h3>
-      <p>Here you can provide a summary of the game rules.</p>
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">Rules</h3>
+      <pre className="whitespace-pre-wrap">{rulesText}</pre>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- document board game rules in `dragon-boardgame-rules.md`
- load these rules on the rules page
- mention rules markdown in boardgame agent file

## Testing
- `npm run biome` *(fails: 403 Forbidden - GET https://registry.npmjs.org/biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b22807c8323bff3aacfb13808a7