### PR TITLE
Improve story navigation

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -54,7 +54,7 @@ Build a personal homepage where visitors can browse board games, read stories, a
 - **Pages & Navigation**: Implement routes for the homepage, board game, stories, and drawings with a shared layout.
 - **Cart & Product Display**: Global cart context, add-to-cart buttons, and a drawer/modal to show items.
 - **Content Sections**: Board game showcase, stories list with full texts, and a virtual drawings gallery with image modal.
-- **Chapter Navigation**: Stories load chapters from Markdown files with corresponding images.
+- **Chapter Navigation**: Chapters load from Markdown files with matching images, ordered by number, and include previous/next links for continuous reading.
 - **Stripe Checkout**: Node.js backend exposes `/create-checkout-session` and handles success/cancel redirects.
 - **Deployment**: Host frontend and backend (e.g., Vercel/Render) and store Stripe secrets as environment variables.
 - **Design Enhancements**: Responsive layout using Tailwind and a full-screen hero section.

--- a/Agent/frontend/stories.md
+++ b/Agent/frontend/stories.md
@@ -4,6 +4,8 @@
 - [x] Provide "Read more" links to full texts
 - [ ] Allow buying stories as PDF or print via cart
 - [ ] (Optional) Add comment section for reader feedback
+- [x] Add previous/next links for continuous chapter reading
+- [x] Sort chapters chronologically and label as "Chapter 1", "Chapter 2", etc.
 
 ## The Summoners' Veiled Cards
 

--- a/tobis-space/src/chapters/index.ts
+++ b/tobis-space/src/chapters/index.ts
@@ -17,23 +17,26 @@ function extractNumber(fileName: string): number {
   return match ? parseInt(match[1]) : 0
 }
 
-const chapters: Chapter[] = Object.entries(chapterModules).map(([path, content]) => {
-  const fileName = path.split('/').pop() ?? ''
-  const number = extractNumber(fileName)
-  const slug = `chapter-${number}`
-  const firstLine = (content as string).split('\n')[0]
-  const title = firstLine.replace(/[*#]/g, '').trim()
+const chapters: Chapter[] = Object.entries(chapterModules)
+  .map(([path, content]) => {
+    const fileName = path.split("/").pop() ?? ""
+    const number = extractNumber(fileName)
+    const slug = `chapter-${number}`
+    const lines = (content as string).split("\n")
+    const body = lines.slice(1).join("\n").trim()
+    const title = `Chapter ${number}`
 
-  let image: string | undefined
-  for (const [imgPath, url] of Object.entries(imageModules)) {
-    const imgName = imgPath.split('/').pop() ?? ''
-    if (extractNumber(imgName) === number) {
-      image = url as string
-      break
+    let image: string | undefined
+    for (const [imgPath, url] of Object.entries(imageModules)) {
+      const imgName = imgPath.split("/").pop() ?? ""
+      if (extractNumber(imgName) === number) {
+        image = url as string
+        break
+      }
     }
-  }
 
-  return { number, slug, title, content: content as string, image }
-}).sort((a, b) => a.number - b.number)
+    return { number, slug, title, content: body, image }
+  })
+  .sort((a, b) => a.number - b.number)
 
 export default chapters

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -1,10 +1,13 @@
-import { useParams } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 import chapters from "../chapters"
 
 export default function Chapter() {
   const { chapterSlug } = useParams()
   const chapter = chapters.find((c) => c.slug === chapterSlug)
   if (!chapter) return <div>Chapter not found</div>
+  const index = chapters.findIndex((c) => c.slug === chapterSlug)
+  const prev = index > 0 ? chapters[index - 1] : undefined
+  const next = index < chapters.length - 1 ? chapters[index + 1] : undefined
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-bold">{chapter.title}</h3>
@@ -12,6 +15,18 @@ export default function Chapter() {
         <img src={chapter.image} alt={chapter.title} className="max-w-full" />
       )}
       <pre className="whitespace-pre-wrap">{chapter.content}</pre>
+      <div className="flex justify-between">
+        {prev && (
+          <Link to={prev.slug} className="text-blue-500 underline">
+            ← {prev.title}
+          </Link>
+        )}
+        {next && (
+          <Link to={next.slug} className="ml-auto text-blue-500 underline">
+            {next.title} →
+          </Link>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add previous/next links to chapters
- standardize chapter titles in loader and sort by number
- clarify chapter navigation tasks in Agent docs

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ce50f1c8323ab22863c8eec9b5b