### PR TITLE
Add English boardgame rules and display with markdown

### DIFF
--- a/Agent/frontend/boardgame.md
+++ b/Agent/frontend/boardgame.md
@@ -4,5 +4,7 @@
 - [x] Allow adding the board game product to the cart
 - [ ] Offer downloadable rulebook PDF
 - [x] Load rules from Markdown file on the Rules page
+- [x] Display rules with proper Markdown styling
+- [x] Provide English translation of the manual
 - [ ] (Optional) Include player testimonials or reviews
 - [ ] Add **Updates** subpage to display changelog entries

--- a/tobis-space/package.json
+++ b/tobis-space/package.json
@@ -17,7 +17,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.23.0",
-    "stripe": "^14.0.0"
+    "stripe": "^14.0.0",
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.5",
@@ -32,6 +33,7 @@
     "globals": "^16.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
+    "@tailwindcss/typography": "^0.5.10",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0"

--- a/tobis-space/src/boardgame/manual/dragon-boardgame-rules.en.md
+++ b/tobis-space/src/boardgame/manual/dragon-boardgame-rules.en.md
@@ -1,0 +1,120 @@
+# 🐉 Dragon Board Game – Rules
+
+## 📦 Setup
+- 🧩 **Game Board – Hexagons**
+  - 🏰 Place the colored castle of the **Dragon Overlord** (with dragon symbol) in the center of the table.
+  - 🔷 Arrange **18 hexagons** randomly around the castle in a larger hexagon:
+    - 🔵 3x Blue (with blue dragon egg)
+    - 🟢 3x Green (with green dragon egg)
+    - 🔴 3x Red (with red dragon egg)
+    - 🌀 3x Portals
+    - 🌈 3x Color change (arrow with colored background)
+    - 👣 3x Movement (footprint symbol)
+  - 🧍 Each player gets a castle hex in their color.
+- 🪙 **Coin Tokens**
+  - 🐉 Place the Dragon Overlord token with the number **16** in the middle.
+  - Scatter dragon tokens from inside out:
+    - Inner: square **8** tokens (gold)
+    - Middle: square **4** tokens (silver)
+    - Outer: square **2** tokens (bronze)
+- 🃏 **Cards**
+  - 🎨 Shuffle the color cards (colorful back) and place them face down on the side.
+  - Create **3 dragon card piles** and put them next to it:
+    - No egg on the back
+    - 🥚🥚 2 eggs
+    - 🥚🥚🥚🥚🥚 5 eggs
+  - Flip over the top card of each pile and place it face up beside it.
+
+## 🧑‍🤝‍🧑 Preparation – Each player receives
+- 🗡️ 1 starting card
+- 📋 1 turn info card / collection info
+- 🃏 5 starting dragon cards (no egg on back)
+- 🐲 2 dragon pieces in player color
+- 🏰 1 castle hex
+- 🟢🔵🔴 one green, blue & red dragon meeple each
+- 👣 4 movement tokens
+
+## 🚀 Game Start
+- 🔁 **First round** – begins counterclockwise.
+- At the start of their first turn each player may:
+  - 🏰 place their starting castle on the board
+  - 🐲 place their 2 dragons on the castle
+- 👉 Then reveal the first color display card – it sets the active color for battles and multicolor tokens.
+- Further rounds continue clockwise, the last player becomes the first player of round two.
+
+## 🔄 Turn Overview – Possible Actions
+A player may combine freely:
+- 🐾 Move a dragon piece
+- 🃏 Draw a card
+- 🐉 Play a card (pay cost)
+- ❌ Discard a card (only at end of turn)
+- 🥚 Collect a dragon egg
+
+## ⚙️ Action Details
+### 🐾 Move a piece
+Move along **white lines** or from your castle also along colored lines.
+Special fields:
+- 👣 Movement hexagon = +1 extra action (max 1× per hexagon)
+- 🌀 Portal = teleport to any other portal
+- 🌈 Color change = spend one action to reveal the next color card (max 1× per turn)
+
+### 🪙 Collect coin token
+Traders reward you based on the strength of your dragon army.
+- 🔵🟢🔴 Colored coin tokens: only if your **dragon life** in that color ≥ token value
+- 🌈 Multicolor tokens: only if you have enough dragon life in the **current display color** (display color ≥ token value)
+- ⚠️ Not collectible during peace rounds
+
+### 👑 Defeat the Dragon Overlord
+Works like a colored coin token – you need equal or more dragon life in the display color. Attacking not allowed in peace rounds.
+
+### ⚔️ Fight an opponent
+- ☮️ Peace round: you may not attack an opponent or enter their space. Multicolor coins cannot be collected either.
+- 🎯 If an opponent blocks you and fighting is allowed:
+  - Execute all permitted fight actions
+  - Compare life tokens in the display color
+  - Winner = player with more life
+  - Tie? → Reveal new color card → second comparison
+  - Still a tie? Both remain in place
+  - If color or life later changes → compare again.
+- 🏁 After the fight:
+  - Loser = piece returns to the castle
+  - Reveal a new color display card
+  - Both players gain 1 life token in the display color
+
+### 🥚 Collect dragon egg
+- Enter the middle of a dragon egg hexagon
+- Each dragon piece may collect 1 egg per egg hexagon per round
+- Usable any time during the turn
+
+### 🃏 Draw cards
+Draw from one of the 3 face-down dragon piles or from the face-up card piles until you have at most five cards.
+- 📌 Each time you draw cards it costs 1 action (for up to 5 cards)
+- Example: draw 3 cards, move the dragon, collect an egg, play a card and want to draw again → costs 2 actions in total.
+
+### 🐉 Play cards
+Pay action and egg costs with your own eggs or placed 🐲 dragons (value = egg cost).
+- Used dragon cards are placed face up next to the three piles (forming new face-up piles).
+- You may have at most 5 active cards.
+- Collection bonus may be tracked with dragon life tokens.
+
+### ❌ Discard cards
+- Free and only allowed at end of turn.
+- Put discarded cards on any of the three face-up piles.
+- Exception: if no face-up pile exists you **must** start one.
+
+## 🏆 Goal
+Defeat the 🐉 Dragon Overlord (16) by having enough dragon life in the display color and winning the fight.
+
+## Game Mode
+Play everyone against everyone or in teams of 2 vs 2.
+
+### With more than 4 players
+Expand the hexagonal board with:
+- For each additional player:
+  - 🔵 1x Blue (with blue dragon egg)
+  - 🟢 1x Green (with green dragon egg)
+  - 🔴 1x Red (with red dragon egg)
+- For every two additional players:
+  - 🌀 1x Portal
+  - 🌈 1x Color change (arrow with colored background)
+  - 👣 1x Movement (footprint symbol)

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -1,11 +1,33 @@
-import React from "react"
-import rulesText from "../boardgame/manual/dragon-boardgame-rules.md?raw"
+import React, { useState } from "react"
+import ReactMarkdown from "react-markdown"
+import rulesDe from "../boardgame/manual/dragon-boardgame-rules.md?raw"
+import rulesEn from "../boardgame/manual/dragon-boardgame-rules.en.md?raw"
 
 export default function BoardGameRules() {
+  const [lang, setLang] = useState<"de" | "en">("de")
+
+  const current = lang === "de" ? rulesDe : rulesEn
+
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">Rules</h3>
-      <pre className="whitespace-pre-wrap">{rulesText}</pre>
+      <div className="flex items-center gap-2">
+        <h3 className="text-lg font-semibold">Rules</h3>
+        <button
+          className={`px-2 py-1 text-sm border rounded ${lang === "de" ? "bg-blue-500 text-white" : ""}`}
+          onClick={() => setLang("de")}
+        >
+          DE
+        </button>
+        <button
+          className={`px-2 py-1 text-sm border rounded ${lang === "en" ? "bg-blue-500 text-white" : ""}`}
+          onClick={() => setLang("en")}
+        >
+          EN
+        </button>
+      </div>
+      <article className="prose max-w-none">
+        <ReactMarkdown>{current}</ReactMarkdown>
+      </article>
     </div>
   )
 }

--- a/tobis-space/tailwind.config.js
+++ b/tobis-space/tailwind.config.js
@@ -7,5 +7,5 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/typography")],
 }


### PR DESCRIPTION
## Summary
- enhance board game instructions with English translation
- render rules using `react-markdown` and Tailwind typography
- add typography plugin and markdown dependency
- update boardgame agent tasks

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d258514cc83239d9afde3338e5267