### PR TITLE
Add About page and update Discord links

### DIFF
--- a/Agent/frontend/README.md
+++ b/Agent/frontend/README.md
@@ -10,3 +10,4 @@ This folder contains separate task lists for each major section of the frontend.
 - `boardgame.md` – Board Game page specifics
 - `stories.md` – Stories page features
 - `design.md` – General design improvements
+- `about.md` – About page with personal info

--- a/Agent/frontend/about.md
+++ b/Agent/frontend/about.md
@@ -1,0 +1,5 @@
+# About Page
+
+- [x] Create an **About** page with personal description
+- [x] Include Discord link to invite users
+- [x] Add `/about` route and navigation entry

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -8,6 +8,7 @@ import BoardGameUpdates from './pages/BoardGameUpdates'
 import Stories from './pages/Stories'
 import Chapter from './pages/Chapter'
 import Drawings from './pages/Drawings'
+import About from './pages/About'
 import CheckoutSuccess from './pages/CheckoutSuccess'
 import CheckoutCancel from './pages/CheckoutCancel'
 
@@ -25,6 +26,7 @@ export default function App() {
           <Route path=":chapterSlug" element={<Chapter />} />
         </Route>
         <Route path="drawings" element={<Drawings />} />
+        <Route path="about" element={<About />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />
       </Route>

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -26,6 +26,9 @@ export default function Header({
           <NavLink to="/drawings" className={linkClass}>
             Drawings
           </NavLink>
+          <NavLink to="/about" className={linkClass}>
+            About
+          </NavLink>
         </nav>
         <button onClick={openCart} className="relative" aria-label="Cart">
           Cart ({items.length})

--- a/tobis-space/src/pages/About.tsx
+++ b/tobis-space/src/pages/About.tsx
@@ -1,0 +1,25 @@
+export default function About() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">About Me</h2>
+      <p>
+        I enjoy exploring new territory—both mentally and physically. Sports have
+        always been a passion: from martial arts and climbing to dance, I've tried a wide range of disciplines.
+      </p>
+      <p>
+        My analytical mindset comes from a master's degree in mechanical engineering (ETH Zurich), my structure from working as a software developer, and my creativity from painting and designing board games.
+      </p>
+      <p>
+        Discord for discussions and more:{' '}
+        <a
+          href="https://discord.gg/ZF9uQWHt"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-500 underline"
+        >
+          https://discord.gg/ZF9uQWHt
+        </a>
+      </p>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/BoardGameCommunity.tsx
+++ b/tobis-space/src/pages/BoardGameCommunity.tsx
@@ -6,7 +6,14 @@ export default function BoardGameCommunity() {
       <h3 className="text-lg font-semibold">Community Links</h3>
       <ul className="list-disc list-inside">
         <li>
-          <a href="https://discord.gg" target="_blank" rel="noreferrer" className="text-blue-500 underline">Discord</a>
+          <a
+            href="https://discord.gg/ZF9uQWHt"
+            target="_blank"
+            rel="noreferrer"
+            className="text-blue-500 underline"
+          >
+            Discord
+          </a>
         </li>
         <li>
           <a href="https://www.instagram.com/dragonsboardgames/" target="_blank" rel="noreferrer" className="text-blue-500 underline">Instagram</a>

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -9,6 +9,18 @@ export default function Stories() {
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Stories</h2>
+      <p>
+        Join the discussion on{' '}
+        <a
+          href="https://discord.gg/ZF9uQWHt"
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-500 underline"
+        >
+          Discord
+        </a>
+        .
+      </p>
       <nav className="flex flex-wrap gap-2">
         {chapters.map((ch) => (
           <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">


### PR DESCRIPTION
## Summary
- add new About page and route with personal description
- update navigation to include About page
- link to new Discord invite in the Board Game community and Stories pages
- document new About page in `Agent/frontend/about.md`

## Testing
- `npm run biome --prefix tobis-space` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d272a769c8323a08a5c151a0cc6a6