### PR TITLE
Add story landing page with general description

### DIFF
--- a/Agent/frontend/stories.md
+++ b/Agent/frontend/stories.md
@@ -13,4 +13,5 @@
 - Images for each chapter in `tobis-space/src/chapters/images`
 - Story page lists chapters and links to `/stories/:chapterSlug`
 - Clicking a chapter shows its text and image
+- `/stories` acts as a landing page with a short story description and chapter list
 - Original story on [Wattpad](https://www.wattpad.com/1528766096-the-summoners%27-veiled-cards-chapter-1-the-fire-in)

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -6,6 +6,7 @@ import BoardGameCommunity from './pages/BoardGameCommunity'
 import BoardGameRules from './pages/BoardGameRules'
 import BoardGameUpdates from './pages/BoardGameUpdates'
 import Stories from './pages/Stories'
+import StoryLanding from './pages/StoryLanding'
 import Chapter from './pages/Chapter'
 import Drawings from './pages/Drawings'
 import CheckoutSuccess from './pages/CheckoutSuccess'
@@ -22,6 +23,7 @@ export default function App() {
           <Route path="updates" element={<BoardGameUpdates />} />
         </Route>
         <Route path="stories" element={<Stories />}>
+          <Route index element={<StoryLanding />} />
           <Route path=":chapterSlug" element={<Chapter />} />
         </Route>
         <Route path="drawings" element={<Drawings />} />

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,41 +1,8 @@
-import { Link, Outlet, useNavigate } from 'react-router-dom'
-import chapters from '../chapters'
-import { useCart } from '../contexts/CartContext'
+import { Outlet } from "react-router-dom"
 
 export default function Stories() {
-  const { addItem } = useCart()
-  const navigate = useNavigate()
-
   return (
     <div className="space-y-4">
-      <h2 className="text-xl">Stories</h2>
-      <nav className="flex flex-wrap gap-2">
-        {chapters.map((ch) => (
-          <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
-            {ch.title}
-          </Link>
-        ))}
-      </nav>
-      <select
-        className="border rounded p-1"
-        onChange={(e) => navigate(e.target.value)}
-        defaultValue=""
-      >
-        <option value="" disabled>
-          Select Chapter
-        </option>
-        {chapters.map((ch) => (
-          <option key={ch.slug} value={ch.slug}>
-            {ch.title}
-          </option>
-        ))}
-      </select>
-      <button
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() => addItem({ id: 'story', name: 'Great Story', price: 4.99 })}
-      >
-        Add to Cart
-      </button>
       <Outlet />
     </div>
   )

--- a/tobis-space/src/pages/StoryLanding.tsx
+++ b/tobis-space/src/pages/StoryLanding.tsx
@@ -1,0 +1,43 @@
+import { Link, useNavigate } from "react-router-dom"
+import chapters from "../chapters"
+import { useCart } from "../contexts/CartContext"
+
+export default function StoryLanding() {
+  const { addItem } = useCart()
+  const navigate = useNavigate()
+  const description =
+    "Varan, a farm slave boy, is forced to flee after a single mistake. With his newfound freedom, he must survive in a world of dangerous beasts, powerful summoners, ruthless gangs, and shifting loyalties. Will he become a thief—or dare to reach for a place among the feared summoners? In a world where allies betray and enemies change, one wrong step could cost more than just freedom."
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">The Summoners' Veiled Cards</h2>
+      <p>{description}</p>
+      <nav className="flex flex-wrap gap-2">
+        {chapters.map((ch) => (
+          <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
+            {ch.title}
+          </Link>
+        ))}
+      </nav>
+      <select
+        className="border rounded p-1"
+        onChange={(e) => navigate(e.target.value)}
+        defaultValue=""
+      >
+        <option value="" disabled>
+          Select Chapter
+        </option>
+        {chapters.map((ch) => (
+          <option key={ch.slug} value={ch.slug}>
+            {ch.title}
+          </option>
+        ))}
+      </select>
+      <button
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => addItem({ id: "story", name: "Great Story", price: 4.99 })}
+      >
+        Add to Cart
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create StoryLanding page with a short summary
- restructure story routing so `/stories` shows StoryLanding
- simplify Stories page to act as a layout
- document landing page in `Agent/frontend/stories.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx --no-install biome format .` *(fails: 403 Forbidden - GET https://registry.npmjs.org/biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d27de133c8323a03477375675b250