### PR TITLE
Fix stories page navigation and imports

### DIFF
--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,6 +1,10 @@
-import { Outlet } from "react-router-dom"
+import { Link, Outlet, useNavigate } from "react-router-dom"
+import chapters from "../chapters"
+import { useCart } from "../contexts/CartContext"
 
 export default function Stories() {
+  const { addItem } = useCart()
+  const navigate = useNavigate()
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Stories</h2>


### PR DESCRIPTION
## Summary
- fix missing imports in `Stories.tsx`

## Testing
- `npm run biome` *(fails: 403 Forbidden - GET https://registry.npmjs.org/biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c973cc483238497f6e90fefb647