### PR TITLE
Fix duplicate story navigation and improve chapter navigation

### DIFF
--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "react-router-dom"
+import { useEffect } from "react"
 import chapters from "../chapters"
 
 export default function Chapter() {
@@ -8,11 +9,18 @@ export default function Chapter() {
   const index = chapters.findIndex((c) => c.slug === chapterSlug)
   const prev = index > 0 ? chapters[index - 1] : undefined
   const next = index < chapters.length - 1 ? chapters[index + 1] : undefined
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }, [chapterSlug])
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-bold">{chapter.title}</h3>
       {chapter.image && (
-        <img src={chapter.image} alt={chapter.title} className="max-w-full" />
+        <img
+          src={chapter.image}
+          alt={chapter.title}
+          className="w-full max-w-md mx-auto"
+        />
       )}
       <pre className="whitespace-pre-wrap">{chapter.content}</pre>
       <div className="flex justify-between">

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,10 +1,7 @@
-import { Link, Outlet, useNavigate } from "react-router-dom"
+import { Link, Outlet } from "react-router-dom"
 import chapters from "../chapters"
-import { useCart } from "../contexts/CartContext"
 
 export default function Stories() {
-  const { addItem } = useCart()
-  const navigate = useNavigate()
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Stories</h2>
@@ -27,26 +24,7 @@ export default function Stories() {
           </Link>
         ))}
       </nav>
-      <select
-        className="border rounded p-1"
-        onChange={(e) => navigate(e.target.value)}
-        defaultValue=""
-      >
-        <option value="" disabled>
-          Select Chapter
-        </option>
-        {chapters.map((ch) => (
-          <option key={ch.slug} value={ch.slug}>
-            {ch.title}
-          </option>
-        ))}
-      </select>
-      <button
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() => addItem({ id: 'story', name: 'Great Story', price: 4.99 })}
-      >
-        Add to Cart
-      </button>
+      
       <Outlet />
     </div>
   )

--- a/tobis-space/src/pages/StoryLanding.tsx
+++ b/tobis-space/src/pages/StoryLanding.tsx
@@ -1,10 +1,7 @@
-import { Link, useNavigate } from "react-router-dom"
+import { Link } from "react-router-dom"
 import chapters from "../chapters"
-import { useCart } from "../contexts/CartContext"
 
 export default function StoryLanding() {
-  const { addItem } = useCart()
-  const navigate = useNavigate()
   const description =
     "Varan, a farm slave boy, is forced to flee after a single mistake. With his newfound freedom, he must survive in a world of dangerous beasts, powerful summoners, ruthless gangs, and shifting loyalties. Will he become a thief—or dare to reach for a place among the feared summoners? In a world where allies betray and enemies change, one wrong step could cost more than just freedom."
   return (
@@ -18,26 +15,7 @@ export default function StoryLanding() {
           </Link>
         ))}
       </nav>
-      <select
-        className="border rounded p-1"
-        onChange={(e) => navigate(e.target.value)}
-        defaultValue=""
-      >
-        <option value="" disabled>
-          Select Chapter
-        </option>
-        {chapters.map((ch) => (
-          <option key={ch.slug} value={ch.slug}>
-            {ch.title}
-          </option>
-        ))}
-      </select>
-      <button
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() => addItem({ id: "story", name: "Great Story", price: 4.99 })}
-      >
-        Add to Cart
-      </button>
+
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove dropdown and cart button from story pages
- resize chapter images
- reset scroll position when changing chapters

## Testing
- `npm run biome` *(fails: 403 Forbidden - GET https://registry.npmjs.org/biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d5fa322988323a0899708aac8213c