### PR TITLE
Add drawings categories with filter

### DIFF
--- a/tobis-space/src/drawings/index.ts
+++ b/tobis-space/src/drawings/index.ts
@@ -1,0 +1,33 @@
+const imageModules = import.meta.glob('./**/*.{jpg,JPG,jpeg,JPEG,png}', {
+\teager: true,
+\timport: 'default',
+})
+
+export interface Drawing {
+\tid: string
+\tname: string
+\tcategory: string
+\tprice: number
+\timage: string
+}
+
+const drawings: Drawing[] = Object.entries(imageModules).map(([path, url]) => {
+\tconst fullPath = path.slice(2)
+\tconst parts = fullPath.split('/')
+\tconst file = parts.pop() as string
+\tconst category = parts.join('/')
+\tconst name = file
+\t\t.replace(/\.[^./]+$/, '')
+\t\t.replace(/[_-]/g, ' ')
+\treturn {
+\t\tid: fullPath,
+\t\tname,
+\t\tcategory,
+\t\tprice: 9.99,
+\t\timage: url as string,
+\t}
+})
+
+export const categories = Array.from(new Set(drawings.map((d) => d.category)))
+
+export default drawings

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,26 +1,38 @@
 import { useState } from "react"
 import { useCart } from "../contexts/CartContext"
-import img1 from "../chapters/images/Chapter1.png"
-import img2 from "../chapters/images/Chapter2.png"
-import img3 from "../chapters/images/Chapter3.png"
-import img4 from "../chapters/images/Chapter4.png"
+import drawings, { categories } from "../drawings"
 
-const artworks = [
-  { id: "drawing1", name: "Drawing 1", price: 9.99, image: img1 },
-  { id: "drawing2", name: "Drawing 2", price: 9.99, image: img2 },
-  { id: "drawing3", name: "Drawing 3", price: 9.99, image: img3 },
-  { id: "drawing4", name: "Drawing 4", price: 9.99, image: img4 },
-]
+const allCategory = "all"
+
+type Artwork = (typeof drawings)[number]
 
 export default function Drawings() {
   const { addItem } = useCart()
-  const [selected, setSelected] = useState<typeof artworks[0] | null>(null)
+  const [selected, setSelected] = useState<Artwork | null>(null)
+  const [filter, setFilter] = useState(allCategory)
+
+  const filtered =
+    filter === allCategory
+      ? drawings
+      : drawings.filter((d) => d.category === filter)
 
   return (
     <div>
       <h2 className="text-xl mb-4">Drawings</h2>
+      <select
+        className="border rounded p-1 mb-4"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+      >
+        <option value={allCategory}>All</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
       <div className="flex flex-wrap justify-center gap-4">
-        {artworks.map((art) => (
+        {filtered.map((art) => (
           <div key={art.id} className="border p-2 w-48">
             <img
               src={art.image}


### PR DESCRIPTION
## Summary
- load all images from `src/drawings` and tag them by folder in `drawings/index.ts`
- update Drawings page to use real drawings and allow filtering by category

## Testing
- `npm run biome` *(fails: 403 Forbidden when trying to download biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d600be7788323b9ed6876c1eb8f60