### PR TITLE
Add boardgame about section

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -1,17 +1,18 @@
 import { Route, Routes } from 'react-router-dom'
 import Layout from './components/Layout'
-import Home from './pages/Home'
+import About from './pages/About'
 import BoardGame from './pages/BoardGame'
+import BoardGameAbout from './pages/BoardGameAbout'
 import BoardGameCommunity from './pages/BoardGameCommunity'
 import BoardGameRules from './pages/BoardGameRules'
 import BoardGameUpdates from './pages/BoardGameUpdates'
+import Chapter from './pages/Chapter'
+import CheckoutCancel from './pages/CheckoutCancel'
+import CheckoutSuccess from './pages/CheckoutSuccess'
+import Drawings from './pages/Drawings'
+import Home from './pages/Home'
 import Stories from './pages/Stories'
 import StoryLanding from './pages/StoryLanding'
-import Chapter from './pages/Chapter'
-import Drawings from './pages/Drawings'
-import About from './pages/About'
-import CheckoutSuccess from './pages/CheckoutSuccess'
-import CheckoutCancel from './pages/CheckoutCancel'
 
 export default function App() {
   return (
@@ -19,6 +20,8 @@ export default function App() {
       <Route path="/" element={<Layout />}>
         <Route index element={<Home />} />
         <Route path="boardgame" element={<BoardGame />}>
+          <Route index element={<BoardGameAbout />} />
+          <Route path="about" element={<BoardGameAbout />} />
           <Route path="community" element={<BoardGameCommunity />} />
           <Route path="rules" element={<BoardGameRules />} />
           <Route path="updates" element={<BoardGameUpdates />} />

--- a/tobis-space/src/boardgame/general/summary.md
+++ b/tobis-space/src/boardgame/general/summary.md
@@ -1,0 +1,15 @@
+# 🐉 **The Dragon’s Tweak: A Game of Strategic Summoning**
+
+In a fractured realm of floating hexes and flickering magic, only the cunning will survive — and only one will tame the Dragon Ruler.
+
+**The Dragon’s Tweak** is a modular strategy game for 2–4 players that blends tactical movement, resource management, and dynamic elemental combat. Each player commands a pair of dragon summoners, vying to gather powerful eggs, control the field, and ultimately challenge the mighty ruler at the heart of the realm.
+
+- **Hex-Based Battlefield** – Build the arena from elemental hexes, each with unique effects
+- **Summon and Sacrifice** – Play dragons from hand, pay with eggs or burn older allies to power stronger ones
+- **Color Shifts Everything** – Battles and token pickups depend on the ever-changing elemental color wheel
+- **Duels of Wits and Power** – Engage in direct confrontations where timing and color dominance decide the victor
+- **Portals, Movement Boosts, and Tactical Turns** – Every tile is a potential opportunity or trap
+
+With every turn, you'll face choices: advance toward the center or fortify your forces? Block your rival or bait them into overextending? And when the moment is right — will you strike for the throne?
+
+**The Dragon’s Tweak** is a tense, ever-evolving contest of positioning, bluffing, and clever combos. Only the most adaptive summoner can rule the dragons.

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -1,13 +1,14 @@
 import { Link, Outlet } from 'react-router-dom'
-import { useCart } from '../contexts/CartContext'
 
 export default function BoardGame() {
-  const { addItem } = useCart()
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Board Game</h2>
       <nav className="flex gap-4">
+        <Link to="about" className="text-blue-500 underline">
+          About
+        </Link>
         <Link to="rules" className="text-blue-500 underline">
           Rules
         </Link>
@@ -18,14 +19,6 @@ export default function BoardGame() {
           Updates
         </Link>
       </nav>
-      <button
-        className="px-4 py-2 bg-blue-500 text-white rounded"
-        onClick={() =>
-          addItem({ id: 'boardgame', name: 'Awesome Board Game', price: 29.99 })
-        }
-      >
-        Add to Cart
-      </button>
       <Outlet />
     </div>
   )

--- a/tobis-space/src/pages/BoardGameAbout.tsx
+++ b/tobis-space/src/pages/BoardGameAbout.tsx
@@ -1,0 +1,13 @@
+import ReactMarkdown from 'react-markdown'
+import summary from '../boardgame/general/summary.md?raw'
+
+export default function BoardGameAbout() {
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">About the Game</h3>
+      <article className="prose max-w-none">
+        <ReactMarkdown>{summary}</ReactMarkdown>
+      </article>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- sort imports in `App.tsx`
- remove Add to Cart button from the board game page
- create `BoardGameAbout` page loading markdown
- default board game route now shows the about page
- store about text under `boardgame/general/summary.md`

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module declarations and types)*

------
https://chatgpt.com/codex/tasks/task_e_685d60c498a08323985245230ba82de3