### PR TITLE
Update asset paths

### DIFF
--- a/Agent/frontend/stories.md
+++ b/Agent/frontend/stories.md
@@ -9,8 +9,8 @@
 
 ## The Summoners' Veiled Cards
 
-- Chapters stored in `tobis-space/src/chapters/chapter-files` as Markdown files
-- Images for each chapter in `tobis-space/src/chapters/images`
+- Chapters stored in `tobis-space/src/files/chapters/chapter-files` as Markdown files
+- Images for each chapter in `tobis-space/src/files/chapters/images`
 - Story page lists chapters and links to `/stories/:chapterSlug`
 - Clicking a chapter shows its text and image
 - `/stories` acts as a landing page with a short story description and chapter list

--- a/tobis-space/src/pages/BoardGameAbout.tsx
+++ b/tobis-space/src/pages/BoardGameAbout.tsx
@@ -1,5 +1,5 @@
 import ReactMarkdown from 'react-markdown'
-import summary from '../boardgame/general/summary.md?raw'
+import summary from '../files/boardgame/general/summary.md?raw'
 
 export default function BoardGameAbout() {
   return (

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -1,7 +1,7 @@
 import  { useState } from "react"
 import ReactMarkdown from "react-markdown"
-import rulesDe from "../boardgame/manual/dragon-boardgame-rules.md?raw"
-import rulesEn from "../boardgame/manual/dragon-boardgame-rules.en.md?raw"
+import rulesDe from "../files/boardgame/manual/dragon-boardgame-rules.md?raw"
+import rulesEn from "../files/boardgame/manual/dragon-boardgame-rules.en.md?raw"
 
 export default function BoardGameRules() {
   const [lang, setLang] = useState<"de" | "en">("de")


### PR DESCRIPTION
## Summary
- fix BoardGame about and rules imports for moved files
- correct chapter path references in stories tasks

## Testing
- `npx biome check tobis-space/src/pages/BoardGameAbout.tsx tobis-space/src/pages/BoardGameRules.tsx Agent/frontend/stories.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d64c009208323bc3ae3a69d0e98f4