### PR TITLE
Improve design with dark theme

### DIFF
--- a/tobis-space/index.html
+++ b/tobis-space/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -24,7 +24,7 @@ export default function Cart() {
           <li key={item.id} className="flex justify-between">
             <span>{item.name}</span>
             <span>{item.price.toFixed(2)} €</span>
-            <button onClick={() => removeItem(item.id)}>X</button>
+            <button onClick={() => removeItem(item.id)} className="ml-2">X</button>
           </li>
         ))}
       </ul>
@@ -37,10 +37,7 @@ export default function Cart() {
             Clear
           </button>
         </div>
-        <button
-          onClick={() => checkout(items)}
-          className="px-4 py-2 bg-green-500 text-white rounded"
-        >
+        <button onClick={() => checkout(items)} className="btn bg-green-600 hover:bg-green-700">
           Buy
         </button>
       </div>

--- a/tobis-space/src/components/CartDrawer.tsx
+++ b/tobis-space/src/components/CartDrawer.tsx
@@ -3,8 +3,8 @@ import Cart from './Cart'
 export default function CartDrawer({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 bg-black/50 flex justify-end z-50">
-      <div className="bg-white text-black h-full w-full max-w-xs sm:w-80 p-4 shadow-xl overflow-y-auto">
-        <button className="mb-2" onClick={onClose}>
+      <div className="bg-white text-black dark:bg-gray-800 dark:text-white h-full w-full max-w-xs sm:w-80 p-4 shadow-xl overflow-y-auto transition-transform">
+        <button className="mb-2 btn bg-gray-300 text-black hover:bg-gray-400" onClick={onClose}>
           Close
         </button>
         <Cart />

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
+import { useTheme } from '../contexts/ThemeContext'
 
 export default function Header({
   openCart,
@@ -7,13 +8,14 @@ export default function Header({
   openCart: () => void
 }) {
   const { items } = useCart()
+  const { dark, toggle } = useTheme()
   const linkClass = ({ isActive }: { isActive: boolean }) =>
-    isActive ? 'text-blue-500' : 'text-gray-700'
+    isActive ? 'text-brand dark:text-brand-light' : 'text-gray-700 dark:text-gray-300'
 
   return (
-    <header className="p-4 border-b">
-      <div className="container mx-auto flex justify-between items-center">
-        <nav className="flex gap-4">
+    <header className="sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur border-b shadow-sm">
+      <div className="container mx-auto flex justify-between items-center p-4">
+        <nav className="flex gap-4 text-sm sm:text-base">
           <NavLink to="/" className={linkClass} end>
             Home
           </NavLink>
@@ -30,9 +32,14 @@ export default function Header({
             About
           </NavLink>
         </nav>
-        <button onClick={openCart} className="relative" aria-label="Cart">
-          Cart ({items.length})
-        </button>
+        <div className="flex items-center gap-4">
+          <button onClick={toggle} aria-label="Toggle theme" className="p-1 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700">
+            {dark ? '☀️' : '🌙'}
+          </button>
+          <button onClick={openCart} className="relative" aria-label="Cart">
+            Cart ({items.length})
+          </button>
+        </div>
       </div>
     </header>
   )

--- a/tobis-space/src/components/Layout.tsx
+++ b/tobis-space/src/components/Layout.tsx
@@ -7,7 +7,7 @@ export default function Layout() {
   const [cartOpen, setCartOpen] = useState(false)
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100 transition-colors">
       <Header openCart={() => setCartOpen(true)} />
       <main className="flex-1 p-4 container mx-auto w-full">
         <Outlet />

--- a/tobis-space/src/contexts/ThemeContext.tsx
+++ b/tobis-space/src/contexts/ThemeContext.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
+
+interface ThemeContextValue {
+  dark: boolean
+  toggle: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [dark, setDark] = useState(() =>
+    document.documentElement.classList.contains("dark")
+  )
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark)
+  }, [dark])
+
+  return (
+    <ThemeContext.Provider value={{ dark, toggle: () => setDark((d) => !d) }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider")
+  return ctx
+}

--- a/tobis-space/src/index.css
+++ b/tobis-space/src/index.css
@@ -2,77 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .btn {
+    @apply px-4 py-2 rounded bg-brand text-white hover:bg-brand-dark transition-colors;
+  }
+}
+
 html,
 body,
 #root {
   height: 100%;
-  margin: 0;
-  width: 100%
-}
-
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  @apply font-sans bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100 transition-colors;
 }

--- a/tobis-space/src/main.tsx
+++ b/tobis-space/src/main.tsx
@@ -2,15 +2,18 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { CartProvider } from './contexts/CartContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 import './index.css'
 import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <CartProvider>
-        <App />
-      </CartProvider>
+      <ThemeProvider>
+        <CartProvider>
+          <App />
+        </CartProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </StrictMode>
 )

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -42,7 +42,7 @@ export default function Drawings() {
             />
             <p className="text-center">{art.name}</p>
             <button
-              className="mt-2 px-2 py-1 bg-blue-500 text-white rounded w-full"
+              className="mt-2 w-full btn"
               onClick={() => addItem(art)}
             >
               Add to Cart
@@ -60,12 +60,12 @@ export default function Drawings() {
             />
             <p className="mb-2 text-center">{selected.name}</p>
             <button
-              className="px-4 py-2 bg-blue-500 text-white rounded"
+              className="btn"
               onClick={() => addItem(selected)}
             >
               Add to Cart
             </button>
-            <button className="ml-2" onClick={() => setSelected(null)}>
+            <button className="ml-2 btn bg-gray-300 text-black hover:bg-gray-400" onClick={() => setSelected(null)}>
               Close
             </button>
           </div>

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <section className="h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-indigo-700 text-white text-center">
+    <section className="h-screen flex items-center justify-center bg-gradient-to-br from-brand to-brand-dark text-white text-center">
       <h1 className="text-4xl sm:text-6xl font-bold">Welcome to Tobi's Space</h1>
     </section>
   )

--- a/tobis-space/tailwind.config.js
+++ b/tobis-space/tailwind.config.js
@@ -4,8 +4,20 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: "class",
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          light: "#c4b5fd",
+          DEFAULT: "#8b5cf6",
+          dark: "#6d28d9",
+        },
+      },
+      fontFamily: {
+        sans: ["Inter", "sans-serif"],
+      },
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 }


### PR DESCRIPTION
## Summary
- add `ThemeProvider` with toggle and context
- update layout and header styling
- create button component styles
- tweak homepage hero colors
- style drawings and cart components
- configure Tailwind for brand colors and dark mode

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d665bf1e883239da56e1160f05348