### PR TITLE
Improve design with dark mode and gallery hover

### DIFF
--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
+import { useEffect, useState } from 'react'
 
 export default function Header({
   openCart,
@@ -7,6 +8,16 @@ export default function Header({
   openCart: () => void
 }) {
   const { items } = useCart()
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (dark) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [dark])
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     isActive ? 'text-blue-500' : 'text-gray-700'
 
@@ -27,9 +38,14 @@ export default function Header({
             Drawings
           </NavLink>
         </nav>
-        <button onClick={openCart} className="relative" aria-label="Cart">
-          Cart ({items.length})
-        </button>
+        <div className="flex items-center gap-4">
+          <button onClick={() => setDark(!dark)} className="px-2 py-1 border rounded">
+            {dark ? 'Light' : 'Dark'} Mode
+          </button>
+          <button onClick={openCart} className="relative" aria-label="Cart">
+            Cart ({items.length})
+          </button>
+        </div>
       </div>
     </header>
   )

--- a/tobis-space/src/components/Layout.tsx
+++ b/tobis-space/src/components/Layout.tsx
@@ -7,12 +7,14 @@ export default function Layout() {
   const [cartOpen, setCartOpen] = useState(false)
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <Header openCart={() => setCartOpen(true)} />
       <main className="flex-1 p-4 container mx-auto w-full">
         <Outlet />
       </main>
-      <footer className="p-4 border-t text-center">&copy; 2024 Tobis Space</footer>
+      <footer className="p-4 border-t border-gray-300 dark:border-gray-700 text-center">
+        &copy; 2024 Tobis Space
+      </footer>
       {cartOpen && <CartDrawer onClose={() => setCartOpen(false)} />}
     </div>
   )

--- a/tobis-space/src/index.css
+++ b/tobis-space/src/index.css
@@ -7,72 +7,15 @@ body,
 #root {
   height: 100%;
   margin: 0;
-  width: 100%
+  width: 100%;
 }
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -13,11 +13,14 @@ export default function Drawings() {
   return (
     <div>
       <h2 className="text-xl mb-4">Drawings</h2>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {artworks.map((art) => (
-          <div key={art.id} className="border p-2">
+          <div
+            key={art.id}
+            className="border p-2 transform transition-transform hover:rotate-[-1deg] hover:scale-105"
+          >
             <div
-              className="h-24 bg-gray-200 mb-2 cursor-pointer"
+              className="h-24 bg-gray-200 dark:bg-gray-700 mb-2 cursor-pointer"
               onClick={() => setSelected(art)}
             />
             <p>{art.name}</p>
@@ -32,8 +35,8 @@ export default function Drawings() {
       </div>
       {selected && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white text-black p-4">
-            <div className="h-48 w-48 bg-gray-200 mb-2" />
+          <div className="bg-white dark:bg-gray-800 text-black dark:text-white p-4">
+            <div className="h-48 w-48 bg-gray-200 dark:bg-gray-700 mb-2" />
             <p className="mb-2">{selected.name}</p>
             <button
               className="px-4 py-2 bg-blue-500 text-white rounded"

--- a/tobis-space/tailwind.config.js
+++ b/tobis-space/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- enable Tailwind class based dark mode
- add dark mode toggle button in header
- style layout and modal for dark mode
- add responsive grid and hover effects in drawings gallery
- simplify default styles

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d68c2d1ac83239e774530cf39dd30