### PR TITLE
Add story overview and chapter carousel

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -12,7 +12,7 @@ import CheckoutSuccess from './pages/CheckoutSuccess'
 import Drawings from './pages/Drawings'
 import Home from './pages/Home'
 import Stories from './pages/Stories'
-import StoryLanding from './pages/StoryLanding'
+import StoryOverview from './pages/StoryOverview'
 
 export default function App() {
   return (
@@ -27,7 +27,7 @@ export default function App() {
           <Route path="updates" element={<BoardGameUpdates />} />
         </Route>
         <Route path="stories" element={<Stories />}>
-          <Route index element={<StoryLanding />} />
+          <Route index element={<StoryOverview />} />
           <Route path=":chapterSlug" element={<Chapter />} />
         </Route>
         <Route path="drawings" element={<Drawings />} />

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -1,20 +1,50 @@
-import { Link, useParams } from "react-router-dom"
+import { Link, useNavigate, useParams } from "react-router-dom"
 import { useEffect } from "react"
 import chapters from "../files/chapters"
 
 export default function Chapter() {
   const { chapterSlug } = useParams()
+  const navigate = useNavigate()
   const chapter = chapters.find((c) => c.slug === chapterSlug)
   if (!chapter) return <div>Chapter not found</div>
   const index = chapters.findIndex((c) => c.slug === chapterSlug)
   const prev = index > 0 ? chapters[index - 1] : undefined
   const next = index < chapters.length - 1 ? chapters[index + 1] : undefined
+  const start = Math.max(0, index - 3)
+  const end = Math.min(chapters.length, index + 4)
+  const nearby = chapters.slice(start, end)
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [chapterSlug])
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-bold">{chapter.title}</h3>
+      <select
+        value={chapter.slug}
+        onChange={(e) => navigate(`../${e.target.value}`)}
+        className="border p-2 rounded"
+      >
+        {chapters.map((ch) => (
+          <option key={ch.slug} value={ch.slug}>
+            {ch.title}
+          </option>
+        ))}
+      </select>
+      <div className="flex gap-2 overflow-x-auto py-2">
+        {nearby.map((ch) => (
+          <Link
+            key={ch.slug}
+            to={`../${ch.slug}`}
+            className={`px-3 py-1 rounded whitespace-nowrap ${
+              ch.slug === chapter.slug
+                ? "bg-blue-500 text-white"
+                : "text-blue-500 underline"
+            }`}
+          >
+            {ch.title}
+          </Link>
+        ))}
+      </div>
       {chapter.image && (
         <img
           src={chapter.image}

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,7 +1,13 @@
-import { Link, Outlet } from "react-router-dom"
+import { Link, Outlet, useLocation, useParams } from "react-router-dom"
 import chapters from "../files/chapters"
 
 export default function Stories() {
+  const location = useLocation()
+  const { chapterSlug } = useParams()
+  const detailTarget = chapterSlug ?? chapters[0].slug
+  const isOverview = location.pathname === "/stories" || location.pathname === "/stories/"
+  const tabClass = (active: boolean) =>
+    active ? "border-b-2 border-blue-500" : "text-blue-500"
   return (
     <div className="space-y-4">
       <h2 className="text-xl">Stories</h2>
@@ -17,14 +23,15 @@ export default function Stories() {
         </a>
         .
       </p>
-      <nav className="flex flex-wrap gap-2">
-        {chapters.map((ch) => (
-          <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
-            {ch.title}
-          </Link>
-        ))}
+      <nav className="flex gap-4 border-b">
+        <Link to="." className={tabClass(isOverview)}>
+          Overview
+        </Link>
+        <Link to={detailTarget} className={tabClass(!isOverview)}>
+          Detail
+        </Link>
       </nav>
-      
+
       <Outlet />
     </div>
   )

--- a/tobis-space/src/pages/StoryOverview.tsx
+++ b/tobis-space/src/pages/StoryOverview.tsx
@@ -1,13 +1,25 @@
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import chapters from "../files/chapters"
 
-export default function StoryLanding() {
+export default function StoryOverview() {
+  const navigate = useNavigate()
   const description =
     "Varan, a farm slave boy, is forced to flee after a single mistake. With his newfound freedom, he must survive in a world of dangerous beasts, powerful summoners, ruthless gangs, and shifting loyalties. Will he become a thief—or dare to reach for a place among the feared summoners? In a world where allies betray and enemies change, one wrong step could cost more than just freedom."
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-bold">The Summoners' Veiled Cards</h2>
       <p>{description}</p>
+      <select
+        onChange={(e) => navigate(e.target.value)}
+        className="border p-2 rounded"
+      >
+        <option value="">Jump to chapter</option>
+        {chapters.map((ch) => (
+          <option key={ch.slug} value={ch.slug}>
+            {ch.title}
+          </option>
+        ))}
+      </select>
       <nav className="flex flex-wrap gap-2">
         {chapters.map((ch) => (
           <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
@@ -15,7 +27,6 @@ export default function StoryLanding() {
           </Link>
         ))}
       </nav>
-
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace `StoryLanding` with `StoryOverview`
- add chapter dropdown to overview page
- support tabs for Stories section
- show chapter dropdown and carousel navigation in detail view

## Testing
- `npx biome format .` *(fails: 403 Forbidden)*
- `npm run --silent --prefix tobis-space build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_685d6ce5ade8832381ec6e4d79399162