### PR TITLE
Improve stories with markdown rendering

### DIFF
--- a/Agent/frontend/stories.md
+++ b/Agent/frontend/stories.md
@@ -6,6 +6,7 @@
 - [ ] (Optional) Add comment section for reader feedback
 - [x] Add previous/next links for continuous chapter reading
 - [x] Sort chapters chronologically and label as "Chapter 1", "Chapter 2", etc.
+- [x] Render chapter text using **ReactMarkdown** so Markdown formatting is applied
 
 ## The Summoners' Veiled Cards
 

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate, useParams } from "react-router-dom"
 import { useEffect } from "react"
+import ReactMarkdown from "react-markdown"
 import chapters from "../files/chapters"
 
 export default function Chapter() {
@@ -52,7 +53,9 @@ export default function Chapter() {
           className="w-full max-w-md mx-auto"
         />
       )}
-      <pre className="whitespace-pre-wrap">{chapter.content}</pre>
+      <article className="prose max-w-none">
+        <ReactMarkdown>{chapter.content}</ReactMarkdown>
+      </article>
       <div className="flex justify-between">
         {prev && (
           <Link to={`../${prev.slug}`} className="text-blue-500 underline">


### PR DESCRIPTION
## Summary
- render chapter content using ReactMarkdown so Markdown formatting is applied
- note new requirement in stories task list

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d76e1debc8323b05d3a4a98576f8f