### PR TITLE
improve dark mode for markdown pages

### DIFF
--- a/tobis-space/src/pages/BoardGameAbout.tsx
+++ b/tobis-space/src/pages/BoardGameAbout.tsx
@@ -5,7 +5,7 @@ export default function BoardGameAbout() {
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">About the Game</h3>
-      <article className="prose max-w-none">
+      <article className="prose max-w-none dark:prose-invert">
         <ReactMarkdown>{summary}</ReactMarkdown>
       </article>
     </div>

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -25,7 +25,7 @@ export default function BoardGameRules() {
           EN
         </button>
       </div>
-      <article className="prose max-w-none">
+      <article className="prose max-w-none dark:prose-invert">
         <ReactMarkdown>{current}</ReactMarkdown>
       </article>
     </div>

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -53,7 +53,7 @@ export default function Chapter() {
           className="w-full max-w-md mx-auto"
         />
       )}
-      <article className="prose max-w-none">
+      <article className="prose max-w-none dark:prose-invert">
         <ReactMarkdown>{chapter.content}</ReactMarkdown>
       </article>
       <div className="flex justify-between">


### PR DESCRIPTION
## Summary
- ensure markdown articles invert text colors for dark mode

## Testing
- `npm run biome` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d78200e6083238401fedf9af322de