### PR TITLE
Enhance UI with FontAwesome icons

### DIFF
--- a/tobis-space/package.json
+++ b/tobis-space/package.json
@@ -18,7 +18,9 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^9.1.0",
     "react-router-dom": "^6.23.0",
-    "stripe": "^14.0.0"
+    "stripe": "^14.0.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.5",

--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -1,4 +1,10 @@
-import { useCart, CartItem } from '../contexts/CartContext'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faCreditCard,
+  faTrash,
+  faXmark,
+} from '@fortawesome/free-solid-svg-icons'
+import { useCart, type CartItem } from '../contexts/CartContext'
 
 async function checkout(items: CartItem[]) {
   const res = await fetch('/create-checkout-session', {
@@ -24,7 +30,9 @@ export default function Cart() {
           <li key={item.id} className="flex justify-between">
             <span>{item.name}</span>
             <span>{item.price.toFixed(2)} €</span>
-            <button onClick={() => removeItem(item.id)} className="ml-2">X</button>
+            <button onClick={() => removeItem(item.id)} className="ml-2">
+              <FontAwesomeIcon icon={faXmark} />
+            </button>
           </li>
         ))}
       </ul>
@@ -34,11 +42,11 @@ export default function Cart() {
             Total {items.reduce((sum, i) => sum + i.price, 0).toFixed(2)} €
           </strong>
           <button onClick={clear} className="ml-2 text-sm text-red-500">
-            Clear
+            <FontAwesomeIcon icon={faTrash} className="mr-1" /> Clear
           </button>
         </div>
         <button onClick={() => checkout(items)} className="btn bg-green-600 hover:bg-green-700">
-          Buy
+          <FontAwesomeIcon icon={faCreditCard} className="mr-1" /> Buy
         </button>
       </div>
     </div>

--- a/tobis-space/src/components/CartDrawer.tsx
+++ b/tobis-space/src/components/CartDrawer.tsx
@@ -1,11 +1,16 @@
 import Cart from './Cart'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faXmark } from '@fortawesome/free-solid-svg-icons'
 
 export default function CartDrawer({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 bg-black/50 flex justify-end z-50">
       <div className="bg-white text-black dark:bg-gray-800 dark:text-white h-full w-full max-w-xs sm:w-80 p-4 shadow-xl overflow-y-auto transition-transform">
-        <button className="mb-2 btn bg-gray-300 text-black hover:bg-gray-400" onClick={onClose}>
-          Close
+        <button
+          className="mb-2 btn bg-gray-300 text-black hover:bg-gray-400"
+          onClick={onClose}
+        >
+          <FontAwesomeIcon icon={faXmark} className="mr-1" /> Close
         </button>
         <Cart />
       </div>

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -1,3 +1,14 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faBookOpen,
+  faDiceD20,
+  faHome,
+  faPaintBrush,
+  faShoppingCart,
+  faSun,
+  faMoon,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons'
 import { NavLink } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
 import { useTheme } from '../contexts/ThemeContext'
@@ -17,27 +28,36 @@ export default function Header({
       <div className="container mx-auto flex justify-between items-center p-4">
         <nav className="flex gap-4 text-sm sm:text-base">
           <NavLink to="/" className={linkClass} end>
-            Home
+            <FontAwesomeIcon icon={faHome} className="mr-1" /> Home
           </NavLink>
           <NavLink to="/boardgame" className={linkClass}>
-            Board Game
+            <FontAwesomeIcon icon={faDiceD20} className="mr-1" /> Board Game
           </NavLink>
           <NavLink to="/stories" className={linkClass}>
-            Stories
+            <FontAwesomeIcon icon={faBookOpen} className="mr-1" /> Stories
           </NavLink>
           <NavLink to="/drawings" className={linkClass}>
-            Drawings
+            <FontAwesomeIcon icon={faPaintBrush} className="mr-1" /> Drawings
           </NavLink>
           <NavLink to="/about" className={linkClass}>
-            About
+            <FontAwesomeIcon icon={faUser} className="mr-1" /> About
           </NavLink>
         </nav>
         <div className="flex items-center gap-4">
-          <button onClick={toggle} aria-label="Toggle theme" className="p-1 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700">
-            {dark ? '☀️' : '🌙'}
+          <button
+            onClick={toggle}
+            aria-label="Toggle theme"
+            className="p-1 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+          >
+            {dark ? (
+              <FontAwesomeIcon icon={faSun} />
+            ) : (
+              <FontAwesomeIcon icon={faMoon} />
+            )}
           </button>
           <button onClick={openCart} className="relative" aria-label="Cart">
-            Cart ({items.length})
+            <FontAwesomeIcon icon={faShoppingCart} className="mr-1" />
+            {items.length}
           </button>
         </div>
       </div>

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,4 +1,9 @@
 import { useState } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import {
+  faCartPlus,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons"
 import { useCart } from "../contexts/CartContext"
 import drawings, { categories } from "../files/drawings"
 
@@ -45,7 +50,7 @@ export default function Drawings() {
               className="mt-2 w-full btn"
               onClick={() => addItem(art)}
             >
-              Add to Cart
+              <FontAwesomeIcon icon={faCartPlus} className="mr-1" /> Add to Cart
             </button>
           </div>
         ))}
@@ -63,10 +68,13 @@ export default function Drawings() {
               className="btn"
               onClick={() => addItem(selected)}
             >
-              Add to Cart
+              <FontAwesomeIcon icon={faCartPlus} className="mr-1" /> Add to Cart
             </button>
-            <button className="ml-2 btn bg-gray-300 text-black hover:bg-gray-400" onClick={() => setSelected(null)}>
-              Close
+            <button
+              className="ml-2 btn bg-gray-300 text-black hover:bg-gray-400"
+              onClick={() => setSelected(null)}
+            >
+              <FontAwesomeIcon icon={faXmark} className="mr-1" /> Close
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add FontAwesome packages to frontend project
- display icons in the header navigation
- show icons in cart, drawer and drawings gallery

## Testing
- `npm run biome` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d7852e89c8323a1214818d0838437