### PR TITLE
Update gallery tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ corresponding file so you can dive deeper when needed.
 - [x] Add modal to preview enlarged artwork
 - [x] Allow adding individual artworks to cart
 - [ ] (Later) Add hover effects or simple 3D illusion
+- [ ] Add a `/drawings/room` subpage for an interactive room view
+- [ ] Let visitors pan or take small steps to look around
+- [ ] Keep movement minimal to stay lightweight
 
 ### Stripe Checkout Integration (`Agent/backend.md`)
 - [x] Set up basic **Node.js Express backend**

--- a/Agent/frontend/gallery.md
+++ b/Agent/frontend/gallery.md
@@ -4,3 +4,6 @@
 - [x] Add modal to preview enlarged artwork
 - [x] Allow adding individual artworks to cart
 - [ ] (Later) Add hover effects or simple 3D illusion
+- [ ] Add a `/drawings/room` subpage for an interactive room view
+- [ ] Let visitors pan or take small steps to look around
+- [ ] Keep movement minimal to stay lightweight

--- a/Agent/frontend/pages-navigation.md
+++ b/Agent/frontend/pages-navigation.md
@@ -4,7 +4,7 @@
   - `/` → Homepage
   - `/boardgame` → Board Game section
   - `/stories` → Stories section
-  - `/drawings` → Painted Drawings (virtual gallery)
   - `/boardgame/updates` → Board Game updates
+  - `/drawings/room` → Walk-around view of the gallery
 - [x] Add navigation bar with active link highlighting
 - [x] Implement a **shared layout** (e.g. with `<Outlet>`)


### PR DESCRIPTION
## Summary
- note ability to enter a simple interactive room from the drawings tab
- list the new `/drawings/room` route in navigation tasks
- mention new task details in overall AGENTS.md

## Testing
- `npm run biome` *(fails: 403 Forbidden when downloading biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d78ff061c83239d0a3b8680531ac8