### PR TITLE
Improve chapter overview list

### DIFF
--- a/tobis-space/src/files/chapters/index.ts
+++ b/tobis-space/src/files/chapters/index.ts
@@ -17,14 +17,42 @@ function extractNumber(fileName: string): number {
   return match ? parseInt(match[1]) : 0
 }
 
+function extractTitle(
+  lines: string[],
+  fileName: string,
+  number: number,
+): { title: string; bodyStart: number } {
+  const firstIndex = lines.findIndex((l) => l.trim() !== "")
+  const firstLine = firstIndex >= 0 ? lines[firstIndex] : ""
+  const cleaned = firstLine
+    .replace(/^#+\s*/, "")
+    .replace(/\*\*/g, "")
+    .trim()
+  const match = cleaned.match(/chapter\s*\d+\s*[:-]\s*(.+)/i)
+  if (match) {
+    return { title: `Chapter ${number}: ${match[1].trim()}`, bodyStart: firstIndex + 1 }
+  }
+  const nameMatch = fileName.match(/Chapter[_\s-]*\d+(.*)\.md/i)
+  if (nameMatch) {
+    const rest = nameMatch[1]
+      .replace(/[-_]+/g, " ")
+      .replace(/\*+/g, "")
+      .trim()
+    if (rest) {
+      return { title: `Chapter ${number}: ${rest}`, bodyStart: firstIndex + 1 }
+    }
+  }
+  return { title: cleaned || `Chapter ${number}`, bodyStart: firstIndex + 1 }
+}
+
 const chapters: Chapter[] = Object.entries(chapterModules)
   .map(([path, content]) => {
     const fileName = path.split("/").pop() ?? ""
     const number = extractNumber(fileName)
     const slug = `chapter-${number}`
     const lines = (content as string).split("\n")
-    const body = lines.slice(1).join("\n").trim()
-    const title = `Chapter ${number}`
+    const { title, bodyStart } = extractTitle(lines, fileName, number)
+    const body = lines.slice(bodyStart).join("\n").trim()
 
     let image: string | undefined
     for (const [imgPath, url] of Object.entries(imageModules)) {

--- a/tobis-space/src/pages/StoryOverview.tsx
+++ b/tobis-space/src/pages/StoryOverview.tsx
@@ -20,13 +20,15 @@ export default function StoryOverview() {
           </option>
         ))}
       </select>
-      <nav className="flex flex-wrap gap-2">
+      <ul className="space-y-1">
         {chapters.map((ch) => (
-          <Link key={ch.slug} to={ch.slug} className="text-blue-500 underline">
-            {ch.title}
-          </Link>
+          <li key={ch.slug}>
+            <Link to={ch.slug} className="text-blue-500 underline block">
+              {ch.title}
+            </Link>
+          </li>
         ))}
-      </nav>
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- automatically parse chapter titles from markdown content
- show vertical chapter list in story overview

## Testing
- `npx biome format src/files/chapters/index.ts src/pages/StoryOverview.tsx` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d7b0dfbcc8323a60d5b7d0117eceb