### PR TITLE
Fix chapter navigation duplicates and improve navigation layout

### DIFF
--- a/tobis-space/src/files/chapters/index.ts
+++ b/tobis-space/src/files/chapters/index.ts
@@ -39,4 +39,12 @@ const chapters: Chapter[] = Object.entries(chapterModules)
   })
   .sort((a, b) => a.number - b.number)
 
-export default chapters
+// Filter out duplicate chapters by slug (based on chapter number)
+const uniqueChapters: Chapter[] = []
+for (const ch of chapters) {
+  if (!uniqueChapters.some((u) => u.slug === ch.slug)) {
+    uniqueChapters.push(ch)
+  }
+}
+
+export default uniqueChapters

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -17,9 +17,24 @@ export default function Chapter() {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [chapterSlug])
+  const navigation = (
+    <div className="flex justify-between">
+      {prev && (
+        <Link to={`../${prev.slug}`} className="text-blue-500 underline">
+          ← {prev.title}
+        </Link>
+      )}
+      {next && (
+        <Link to={`../${next.slug}`} className="ml-auto text-blue-500 underline">
+          {next.title} →
+        </Link>
+      )}
+    </div>
+  )
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-bold">{chapter.title}</h3>
+      {navigation}
       <select
         value={chapter.slug}
         onChange={(e) => navigate(`../${e.target.value}`)}
@@ -56,18 +71,7 @@ export default function Chapter() {
       <article className="prose max-w-none dark:prose-invert">
         <ReactMarkdown>{chapter.content}</ReactMarkdown>
       </article>
-      <div className="flex justify-between">
-        {prev && (
-          <Link to={`../${prev.slug}`} className="text-blue-500 underline">
-            ← {prev.title}
-          </Link>
-        )}
-        {next && (
-          <Link to={`../${next.slug}`} className="ml-auto text-blue-500 underline">
-            {next.title} →
-          </Link>
-        )}
-      </div>
+      {navigation}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- filter duplicate chapters when loading markdown files
- show previous/next chapter links at the top of the chapter page

## Testing
- `npm run biome` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d7bd51da88323bd8625b774cec132