### PR TITLE
Remove horizontally scrollable chapters list

### DIFF
--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -11,9 +11,6 @@ export default function Chapter() {
   const index = chapters.findIndex((c) => c.slug === chapterSlug)
   const prev = index > 0 ? chapters[index - 1] : undefined
   const next = index < chapters.length - 1 ? chapters[index + 1] : undefined
-  const start = Math.max(0, index - 3)
-  const end = Math.min(chapters.length, index + 4)
-  const nearby = chapters.slice(start, end)
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "smooth" })
   }, [chapterSlug])
@@ -46,21 +43,6 @@ export default function Chapter() {
           </option>
         ))}
       </select>
-      <div className="flex gap-2 overflow-x-auto py-2">
-        {nearby.map((ch) => (
-          <Link
-            key={ch.slug}
-            to={`../${ch.slug}`}
-            className={`px-3 py-1 rounded whitespace-nowrap ${
-              ch.slug === chapter.slug
-                ? "bg-blue-500 text-white"
-                : "text-blue-500 underline"
-            }`}
-          >
-            {ch.title}
-          </Link>
-        ))}
-      </div>
       {chapter.image && (
         <img
           src={chapter.image}


### PR DESCRIPTION
## Summary
- update the `Chapter` page to drop the horizontal chapter list

## Testing
- `npm --prefix tobis-space run biome` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685d8d71ecf88323bcd9bcd205b42949