### PR TITLE
Add error boundary handling

### DIFF
--- a/tobis-space/src/components/ErrorBoundary.tsx
+++ b/tobis-space/src/components/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import { Component, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
+import ErrorPage from '../pages/ErrorPage'
+
+interface BoundaryState {
+  hasError: boolean
+}
+
+class Boundary extends Component<{ children: ReactNode }, BoundaryState> {
+  state: BoundaryState = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorPage />
+    }
+    return this.props.children
+  }
+}
+
+export default function ErrorBoundary({ children }: { children: ReactNode }) {
+  const location = useLocation()
+  return <Boundary key={location.pathname}>{children}</Boundary>
+}

--- a/tobis-space/src/main.tsx
+++ b/tobis-space/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { CartProvider } from './contexts/CartContext'
 import { ThemeProvider } from './contexts/ThemeContext'
+import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 import App from './App'
 
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
     <BrowserRouter>
       <ThemeProvider>
         <CartProvider>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </CartProvider>
       </ThemeProvider>
     </BrowserRouter>

--- a/tobis-space/src/pages/ErrorPage.tsx
+++ b/tobis-space/src/pages/ErrorPage.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from 'react-router-dom'
+
+export default function ErrorPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center p-4 gap-4">
+      <h1 className="text-2xl font-bold">Something went wrong</h1>
+      <p>We encountered an unexpected error.</p>
+      <div className="flex gap-4">
+        <button
+          onClick={() => navigate(-1)}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Go Back
+        </button>
+        <button
+          onClick={() => navigate('/')}
+          className="px-4 py-2 bg-gray-600 text-white rounded"
+        >
+          Home
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create error page for navigation recovery
- add error boundary component
- wrap the app with the boundary in `main.tsx`

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d901117788323ab9c6fb08e8ce06f