### PR TITLE
Add sine wave theme to hero

### DIFF
--- a/tobis-space/src/components/SineBackground.tsx
+++ b/tobis-space/src/components/SineBackground.tsx
@@ -1,0 +1,19 @@
+import { SVGProps } from "react"
+
+export default function SineBackground(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 1440 320"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="absolute inset-0 h-full w-full text-brand-dark"
+      {...props}
+    >
+      <path
+        d="M0 160c48-32 96-64 144-64s96 32 144 48 96 16 144-16 96-96 144-96 96 64 144 96 96 32 144 16 96-48 144-48 96 32 144 48v224H0Z"
+        fill="currentColor"
+        fillOpacity="0.15"
+      />
+    </svg>
+  )
+}

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,7 +1,12 @@
+import SineBackground from '../components/SineBackground'
+
 export default function Home() {
   return (
-    <section className="h-screen flex items-center justify-center bg-gradient-to-br from-night to-brand-dark text-white text-center">
-      <h1 className="text-4xl sm:text-6xl font-bold">Welcome to Tobi's Space</h1>
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-night to-brand-dark text-white text-center">
+      <SineBackground />
+      <h1 className="relative z-10 text-4xl sm:text-6xl font-bold">
+        Welcome to Tobi's Space
+      </h1>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- create `SineBackground` component with SVG wave
- show this background on the homepage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx biome format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/biome)*

------
https://chatgpt.com/codex/tasks/task_e_685d9202c358832381203a31421c3427