### PR TITLE
Fix drawings page height handling

### DIFF
--- a/tobis-space/src/index.css
+++ b/tobis-space/src/index.css
@@ -8,6 +8,8 @@ body,
   height: 100%;
   margin: 0;
   width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 :root {

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -11,7 +11,7 @@ export default function Drawings() {
   const [selected, setSelected] = useState<typeof artworks[0] | null>(null)
 
   return (
-    <div>
+    <div className="min-h-screen flex flex-col">
       <h2 className="text-xl mb-4">Drawings</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {artworks.map((art) => (


### PR DESCRIPTION
## Summary
- make the root element flex to ensure children can expand
- give the drawings page a `min-h-screen` wrapper so components like the virtual room fill the viewport

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d94032ebc8323a8c96b709bcc6a6a