### PR TITLE
Improve light theme and page headers

### DIFF
--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header({
     isActive ? 'text-brand-neon' : 'text-gray-700 dark:text-gray-300'
 
   return (
-    <header className="sticky top-0 z-40 bg-white/80 dark:bg-gray-800/80 backdrop-blur border-b shadow-sm">
+    <header className="sticky top-0 z-40 bg-gray-100/90 dark:bg-gray-800/80 text-gray-900 dark:text-gray-100 backdrop-blur border-b border-gray-200 dark:border-gray-700 shadow-sm">
       <div className="container mx-auto flex justify-between items-center p-4">
         <nav className="flex gap-4 text-sm sm:text-base">
           <NavLink to="/" className={linkClass} end>

--- a/tobis-space/src/index.css
+++ b/tobis-space/src/index.css
@@ -9,6 +9,12 @@
   .card {
     @apply border rounded bg-white dark:bg-gray-800 p-4 hover:shadow-lg transition transform hover:-translate-y-1;
   }
+  .page-title {
+    @apply text-2xl font-bold mb-4 text-brand-dark dark:text-brand-light;
+  }
+  .subpage-title {
+    @apply text-xl font-semibold mb-2 text-brand dark:text-brand-neon;
+  }
 }
 
 html,
@@ -18,5 +24,5 @@ body,
 }
 
 body {
-  @apply font-sans bg-night text-gray-200 dark:bg-gray-950 dark:text-gray-100 transition-colors;
+  @apply font-sans bg-gray-50 text-gray-800 dark:bg-night dark:text-gray-100 transition-colors;
 }

--- a/tobis-space/src/pages/About.tsx
+++ b/tobis-space/src/pages/About.tsx
@@ -1,7 +1,7 @@
 export default function About() {
   return (
     <div className="space-y-4">
-      <h2 className="text-xl font-semibold">About Me</h2>
+      <h2 className="page-title">About Me</h2>
       <p>
         I enjoy exploring new territory—both mentally and physically. Sports have
         always been a passion: from martial arts and climbing to dance, I've tried a wide range of disciplines.

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -4,7 +4,7 @@ export default function BoardGame() {
 
   return (
     <div className="space-y-4">
-      <h2 className="text-xl">Board Game</h2>
+      <h2 className="page-title">Board Game</h2>
       <nav className="flex gap-4">
         <Link to="about" className="text-blue-500 underline">
           About

--- a/tobis-space/src/pages/BoardGameAbout.tsx
+++ b/tobis-space/src/pages/BoardGameAbout.tsx
@@ -4,7 +4,7 @@ import summary from '../files/boardgame/general/summary.md?raw'
 export default function BoardGameAbout() {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">About the Game</h3>
+      <h3 className="subpage-title">About the Game</h3>
       <article className="prose max-w-none dark:prose-invert">
         <ReactMarkdown>{summary}</ReactMarkdown>
       </article>

--- a/tobis-space/src/pages/BoardGameCommunity.tsx
+++ b/tobis-space/src/pages/BoardGameCommunity.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 export default function BoardGameCommunity() {
   return (
     <div className="space-y-2">
-      <h3 className="text-lg font-semibold">Community Links</h3>
+      <h3 className="subpage-title">Community Links</h3>
       <ul className="list-disc list-inside">
         <li>
           <a

--- a/tobis-space/src/pages/BoardGameRules.tsx
+++ b/tobis-space/src/pages/BoardGameRules.tsx
@@ -11,7 +11,7 @@ export default function BoardGameRules() {
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
-        <h3 className="text-lg font-semibold">Rules</h3>
+        <h3 className="subpage-title">Rules</h3>
         <button
           className={`px-2 py-1 text-sm border rounded ${lang === "de" ? "bg-blue-500 text-white" : ""}`}
           onClick={() => setLang("de")}

--- a/tobis-space/src/pages/BoardGameUpdates.tsx
+++ b/tobis-space/src/pages/BoardGameUpdates.tsx
@@ -16,7 +16,7 @@ const updates: Update[] = [
 export default function BoardGameUpdates() {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold">Game Updates</h3>
+      <h3 className="subpage-title">Game Updates</h3>
       <ul className="space-y-4">
         {updates.map((u) => (
           <li key={u.version} className="border p-4">

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -30,7 +30,7 @@ export default function Chapter() {
   )
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-bold">{chapter.title}</h3>
+      <h3 className="subpage-title">{chapter.title}</h3>
       {navigation}
       <select
         value={chapter.slug}

--- a/tobis-space/src/pages/CheckoutCancel.tsx
+++ b/tobis-space/src/pages/CheckoutCancel.tsx
@@ -1,3 +1,3 @@
 export default function CheckoutCancel() {
-  return <h2 className="text-xl">Checkout canceled.</h2>
+  return <h2 className="page-title">Checkout canceled.</h2>
 }

--- a/tobis-space/src/pages/CheckoutSuccess.tsx
+++ b/tobis-space/src/pages/CheckoutSuccess.tsx
@@ -1,3 +1,3 @@
 export default function CheckoutSuccess() {
-  return <h2 className="text-xl">Thank you for your purchase!</h2>
+  return <h2 className="page-title">Thank you for your purchase!</h2>
 }

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -21,7 +21,7 @@ export default function Drawings() {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl">Drawings</h2>
+        <h2 className="page-title">Drawings</h2>
         <Link to="/drawings/room" className="text-blue-500 underline">
           Virtual Room
         </Link>

--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -85,7 +85,7 @@ export default function DrawingsRoom() {
         <Link to="/drawings" className="text-blue-500 underline flex items-center">
           <FontAwesomeIcon icon={faArrowLeft} className="mr-1" /> Back to gallery
         </Link>
-        <h2 className="text-xl font-bold">Virtual Room</h2>
+        <h2 className="page-title">Virtual Room</h2>
       </div>
       <Canvas className="w-full h-[calc(100vh-6rem)]">
         <Suspense

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -10,7 +10,7 @@ export default function Stories() {
     active ? "border-b-2 border-blue-500" : "text-blue-500"
   return (
     <div className="space-y-4">
-      <h2 className="text-xl">Stories</h2>
+      <h2 className="page-title">Stories</h2>
       <p>
         Join the discussion on{' '}
         <a

--- a/tobis-space/src/pages/StoryOverview.tsx
+++ b/tobis-space/src/pages/StoryOverview.tsx
@@ -7,7 +7,7 @@ export default function StoryOverview() {
     "Varan, a farm slave boy, is forced to flee after a single mistake. With his newfound freedom, he must survive in a world of dangerous beasts, powerful summoners, ruthless gangs, and shifting loyalties. Will he become a thief—or dare to reach for a place among the feared summoners? In a world where allies betray and enemies change, one wrong step could cost more than just freedom."
   return (
     <div className="space-y-4">
-      <h2 className="text-xl font-bold">The Summoners' Veiled Cards</h2>
+      <h2 className="page-title">The Summoners' Veiled Cards</h2>
       <p>{description}</p>
       <select
         onChange={(e) => navigate(e.target.value)}


### PR DESCRIPTION
## Summary
- tweak main header background for better visibility in light mode
- lighten body colors and add reusable heading classes
- apply `page-title` and `subpage-title` across pages

## Testing
- `npm run biome` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d967cab648323b2297186435b4c39