### PR TITLE
Fix dark mode styling for dropdowns

### DIFF
--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -35,7 +35,7 @@ export default function Chapter() {
       <select
         value={chapter.slug}
         onChange={(e) => navigate(`../${e.target.value}`)}
-        className="border p-2 rounded"
+        className="border p-2 rounded bg-white dark:bg-gray-700 dark:text-white dark:border-gray-600"
       >
         {chapters.map((ch) => (
           <option key={ch.slug} value={ch.slug}>

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -27,7 +27,7 @@ export default function Drawings() {
         </Link>
       </div>
       <select
-        className="border rounded p-1 mb-4"
+        className="border rounded p-1 mb-4 bg-white dark:bg-gray-700 dark:text-white dark:border-gray-600"
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
       >

--- a/tobis-space/src/pages/StoryOverview.tsx
+++ b/tobis-space/src/pages/StoryOverview.tsx
@@ -11,7 +11,7 @@ export default function StoryOverview() {
       <p>{description}</p>
       <select
         onChange={(e) => navigate(e.target.value)}
-        className="border p-2 rounded"
+        className="border p-2 rounded bg-white dark:bg-gray-700 dark:text-white dark:border-gray-600"
       >
         <option value="">Jump to chapter</option>
         {chapters.map((ch) => (


### PR DESCRIPTION
## Summary
- style dropdowns for dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx biome format tobis-space/src/pages/StoryOverview.tsx` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a9932348323b7b203b1a17f3aa7