### PR TITLE
Limit drawings to single cart addition

### DIFF
--- a/tobis-space/src/components/Card.tsx
+++ b/tobis-space/src/components/Card.tsx
@@ -1,8 +1,16 @@
 import { type ReactNode } from 'react'
 
-export default function Card({ children }: { children: ReactNode }) {
+export default function Card({
+  children,
+  className = '',
+}: {
+  children: ReactNode
+  className?: string
+}) {
   return (
-    <div className="card shadow-md hover:shadow-lg transition-shadow p-4 rounded bg-white dark:bg-gray-800">
+    <div
+      className={`card shadow-md hover:shadow-lg transition-shadow p-4 rounded bg-white dark:bg-gray-800 ${className}`}
+    >
       {children}
     </div>
   )

--- a/tobis-space/src/contexts/CartContext.tsx
+++ b/tobis-space/src/contexts/CartContext.tsx
@@ -4,6 +4,7 @@ export interface CartItem {
   id: string
   name: string
   price: number
+  multiple?: boolean
 }
 
 interface CartContextValue {
@@ -18,7 +19,13 @@ const CartContext = createContext<CartContextValue | undefined>(undefined)
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([])
 
-  const addItem = (item: CartItem) => setItems((prev) => [...prev, item])
+  const addItem = (item: CartItem) =>
+    setItems((prev) => {
+      if (!item.multiple && prev.some((i) => i.id === item.id)) {
+        return prev
+      }
+      return [...prev, item]
+    })
   const removeItem = (id: string) =>
     setItems((prev) => prev.filter((i) => i.id !== id))
   const clear = () => setItems([])

--- a/tobis-space/src/files/drawings/index.ts
+++ b/tobis-space/src/files/drawings/index.ts
@@ -15,6 +15,7 @@ for (const data of Object.values(csvModules)) {
 interface Info {
   description: string
   price: number
+  multiple: boolean
 }
 
 const infoMap = new Map<string, Info>()
@@ -24,11 +25,12 @@ if (csvData) {
     .split('\n')
     .slice(1)
     .forEach((line) => {
-      const [id, description, price] = line.split(',')
+      const [id, description, price, multiple] = line.split(',')
       if (id) {
         infoMap.set(id.trim(), {
           description: (description || 'missing description').trim(),
           price: parseFloat(price) || 0,
+          multiple: multiple?.trim() === 'true',
         })
       }
     })
@@ -41,6 +43,7 @@ export interface Drawing {
   price: number
   image: string
   description: string
+  multiple: boolean
 }
 
 const drawings: Drawing[] = Object.entries(imageModules).map(([path, module]) => {
@@ -56,6 +59,7 @@ const drawings: Drawing[] = Object.entries(imageModules).map(([path, module]) =>
   const info = infoMap.get(fullPath) ?? {
     description: 'missing description',
     price: 0,
+    multiple: false,
   }
 
   return {
@@ -65,6 +69,7 @@ const drawings: Drawing[] = Object.entries(imageModules).map(([path, module]) =>
     price: info.price,
     image: module as string,
     description: info.description,
+    multiple: info.multiple,
   }
 })
 

--- a/tobis-space/src/files/drawings/info.csv
+++ b/tobis-space/src/files/drawings/info.csv
@@ -1,5 +1,5 @@
-id,description,price
-Charcoal/Angi_final.jpg,missing description,12.99
-Cup/Cup1_foto.jpg,missing description,8.50
-Pencil/AnnaPainted.jpeg,missing description,11.25
-canvas/Acryl/IMG_2519.JPG,missing description,15.75
+id,description,price,multiple
+Charcoal/Angi_final.jpg,missing description,12.99,false
+Cup/Cup1_foto.jpg,missing description,8.50,false
+Pencil/AnnaPainted.jpeg,missing description,11.25,false
+canvas/Acryl/IMG_2519.JPG,missing description,15.75,false

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -13,7 +13,7 @@ const allCategory = "all"
 export default function Drawings() {
   const [selected, setSelected] = useState<string | null>(null)
   const [filter, setFilter] = useState(allCategory)
-  const { addItem } = useCart()
+  const { addItem, items } = useCart()
 
   const filtered =
     filter === allCategory
@@ -41,8 +41,14 @@ export default function Drawings() {
         ))}
       </select>
       <div className="flex flex-wrap justify-center gap-4">
-        {filtered.map((art) => (
-          <Card key={art.id}>
+        {filtered.map((art) => {
+          const inCart = items.some((i) => i.id === art.id)
+          const canAdd = art.multiple || !inCart
+          return (
+            <Card
+              key={art.id}
+              className={inCart ? 'bg-green-200 dark:bg-green-900' : ''}
+            >
             {selected === art.id ? (
               <div className="w-48 h-48 flex flex-col items-center justify-center text-center space-y-2">
                 <p className="font-semibold">{art.name}</p>
@@ -51,10 +57,16 @@ export default function Drawings() {
                 <div className="flex gap-2">
                   <Button
                     onClick={() =>
-                      addItem({ id: art.id, name: art.name, price: art.price })
+                      addItem({
+                        id: art.id,
+                        name: art.name,
+                        price: art.price,
+                        multiple: art.multiple,
+                      })
                     }
+                    disabled={!canAdd}
                   >
-                    Add to Cart
+                    {inCart && !art.multiple ? 'Added' : 'Add to Cart'}
                   </Button>
                   <Button
                     className="bg-gray-300 text-black hover:bg-gray-400"
@@ -73,10 +85,14 @@ export default function Drawings() {
                   onClick={() => setSelected(art.id)}
                 />
                 <p className="text-center">{art.name}</p>
+                {inCart && !art.multiple && (
+                  <p className="text-sm text-green-600">Added to cart</p>
+                )}
               </>
             )}
           </Card>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow passing custom class names to `<Card>`
- track single vs multi purchase capability via new `multiple` flag
- parse the new flag from `drawings/info.csv`
- highlight drawings already in cart and disable repeat adds
- prevent duplicate items in cart in `CartContext`

## Testing
- `npm run build` *(fails: Cannot find module 'vite')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d9b42e6fc832393d2c5a8c87a6fcd