### PR TITLE
Add Software page

### DIFF
--- a/tobis-space/public/cv.pdf
+++ b/tobis-space/public/cv.pdf
@@ -1,0 +1,1 @@
+Placeholder CV

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -14,6 +14,7 @@ import DrawingsRoom from './pages/DrawingsRoom'
 import Home from './pages/Home'
 import Stories from './pages/Stories'
 import StoryOverview from './pages/StoryOverview'
+import Software from './pages/Software'
 
 export default function App() {
   return (
@@ -33,6 +34,7 @@ export default function App() {
         </Route>
         <Route path="drawings" element={<Drawings />} />
         <Route path="drawings/room" element={<DrawingsRoom />} />
+        <Route path="software" element={<Software />} />
         <Route path="about" element={<About />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   faDiceD20,
   faHome,
   faPaintBrush,
+  faCode,
   faShoppingCart,
   faSun,
   faMoon,
@@ -38,6 +39,9 @@ export default function Header({
           </NavLink>
           <NavLink to="/drawings" className={linkClass}>
             <FontAwesomeIcon icon={faPaintBrush} className="mr-1" /> Drawings
+          </NavLink>
+          <NavLink to="/software" className={linkClass}>
+            <FontAwesomeIcon icon={faCode} className="mr-1" /> Software
           </NavLink>
           <NavLink to="/about" className={linkClass}>
             <FontAwesomeIcon icon={faUser} className="mr-1" /> About

--- a/tobis-space/src/pages/Software.tsx
+++ b/tobis-space/src/pages/Software.tsx
@@ -1,0 +1,27 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faDownload, faEnvelope } from '@fortawesome/free-solid-svg-icons'
+
+export default function Software() {
+  return (
+    <div className="space-y-4">
+      <h2 className="page-title">Software Development</h2>
+      <p>
+        I build web applications using TypeScript, React, and Node.js. My
+        engineering background helps me approach problems analytically while my
+        creativity drives user-focused solutions.
+      </p>
+      <p>
+        <a href="/cv.pdf" target="_blank" rel="noreferrer" className="text-blue-500 underline">
+          <FontAwesomeIcon icon={faDownload} className="mr-1" /> View my CV
+        </a>
+      </p>
+      <p>
+        Interested in working together? Book me via{' '}
+        <a href="mailto:booking@example.com" className="text-blue-500 underline">
+          <FontAwesomeIcon icon={faEnvelope} className="mr-1" /> email
+        </a>
+        .
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new `Software` page with CV link and booking instructions
- create placeholder `cv.pdf`
- route `/software` in the router
- add `Software` link with icon to the header navigation

## Testing
- `node_modules/.bin/biome format .` *(fails: No such file or directory)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862b098704c83238c513825cd8b70bd