### PR TITLE
Add constant wall distance in virtual room

### DIFF
--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -1,11 +1,18 @@
-import { Suspense, useRef } from 'react'
+import { Suspense, useEffect, useRef } from "react"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faSpinner } from '@fortawesome/free-solid-svg-icons'
-import { Canvas, useFrame, useLoader } from '@react-three/fiber'
-import { Html, OrbitControls } from '@react-three/drei'
-import { DoubleSide, Group, Mesh, TextureLoader } from 'three'
+import { Canvas, useFrame, useLoader, useThree } from "@react-three/fiber"
+import { Html, OrbitControls } from "@react-three/drei"
+import {
+  DoubleSide,
+  Group,
+  Mesh,
+  TextureLoader,
+  RepeatWrapping,
+} from "three"
 import { Link } from 'react-router-dom'
-import drawings from '../files/drawings'
+import drawings from "../files/drawings"
+import wallImg from "../assets/drawings/wall.png"
 
 const placements = drawings.map(() => ({
   surface: ['left', 'right', 'ceiling'][Math.floor(Math.random() * 3)] as
@@ -20,6 +27,9 @@ const placements = drawings.map(() => ({
 }))
 
 const ART_SPACING = 5
+const SEGMENT_WIDTH = drawings.length * ART_SPACING
+const CAMERA_DISTANCE = 7
+const WALL_DISTANCE = 8
 
 function SpinningArt({
   texture,
@@ -42,19 +52,36 @@ function SpinningArt({
 
 function GallerySegment({ group }: { group: React.MutableRefObject<Group | null> }) {
   const textures = useLoader(TextureLoader, drawings.map((d) => d.image))
+  const wallTexture = useLoader(TextureLoader, wallImg)
   const spacing = ART_SPACING
-  const wallDistance = 8
+  const wallDistance = WALL_DISTANCE
+  const wallHeight = 5
+
+  wallTexture.wrapS = RepeatWrapping
+  wallTexture.wrapT = RepeatWrapping
+  wallTexture.repeat.set(SEGMENT_WIDTH / 4, 2)
+
+  const wallCenterX = SEGMENT_WIDTH / 2 - spacing / 2
+
   return (
     <group ref={group}>
+      <mesh position={[wallCenterX, 0, -wallDistance]}>
+        <planeGeometry args={[SEGMENT_WIDTH, wallHeight]} />
+        <meshBasicMaterial map={wallTexture} side={DoubleSide} />
+      </mesh>
+      <mesh position={[wallCenterX, 0, wallDistance]} rotation={[0, Math.PI, 0]}>
+        <planeGeometry args={[SEGMENT_WIDTH, wallHeight]} />
+        <meshBasicMaterial map={wallTexture} side={DoubleSide} />
+      </mesh>
       {drawings.map((art, index) => {
         const rand = placements[index]
         const pos: [number, number, number] = [index * spacing, 0, 0]
         let rot: [number, number, number] = [0, 0, rand.rotZ]
 
-        if (rand.surface === 'left') {
+        if (rand.surface === "left") {
           pos[1] = rand.offsetY
           pos[2] = -wallDistance + rand.offsetZ
-        } else if (rand.surface === 'right') {
+        } else if (rand.surface === "right") {
           pos[1] = rand.offsetY
           pos[2] = wallDistance + rand.offsetZ
           rot = [0, Math.PI, rand.rotZ]
@@ -80,19 +107,36 @@ function GallerySegment({ group }: { group: React.MutableRefObject<Group | null>
 }
 
 export default function DrawingsRoom() {
+  const camX = useRef(0)
+  const controlsRef = useRef<any>(null)
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") camX.current += 0.5
+      if (e.key === "ArrowLeft") camX.current -= 0.5
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [])
   function GalleryScene() {
+    const { camera } = useThree()
+    const controls = controlsRef.current
     const left = useRef<Group | null>(null)
     const center = useRef<Group | null>(null)
     const right = useRef<Group | null>(null)
 
-    const segmentWidth = drawings.length * ART_SPACING
-
-    useFrame(({ camera }) => {
-      const offset = Math.floor(camera.position.x / segmentWidth)
+    useFrame(() => {
+      camera.position.set(camX.current, 1.5, -CAMERA_DISTANCE)
+      const offset = Math.floor(camera.position.x / SEGMENT_WIDTH)
       if (left.current && center.current && right.current) {
-        left.current.position.x = segmentWidth * (offset - 1)
-        center.current.position.x = segmentWidth * offset
-        right.current.position.x = segmentWidth * (offset + 1)
+        left.current.position.x = SEGMENT_WIDTH * (offset - 1)
+        center.current.position.x = SEGMENT_WIDTH * offset
+        right.current.position.x = SEGMENT_WIDTH * (offset + 1)
+      }
+
+      if (controls) {
+        controls.target.set(camera.position.x, 1.5, -WALL_DISTANCE)
+        controls.update()
       }
     })
 
@@ -115,7 +159,11 @@ export default function DrawingsRoom() {
         <h2 className="page-title text-white">Virtual Room</h2>
       </div>
 
-        <Canvas className="w-full h-full" style={{ height: '90vh' }}   camera={{ position: [0, 1.5, 0.001] }} >
+        <Canvas
+          className="w-full h-full"
+          style={{ height: "90vh" }}
+          camera={{ position: [0, 1.5, -CAMERA_DISTANCE] }}
+        >
         <Suspense
           fallback={
             <Html center>
@@ -127,11 +175,11 @@ export default function DrawingsRoom() {
           }
         >
           <OrbitControls
+            ref={controlsRef}
             enablePan={false}
             enableZoom={false}
-            target={[0, 1.5, 0]}
-            minDistance={0.001}
-            maxDistance={0.001}
+            minDistance={WALL_DISTANCE - CAMERA_DISTANCE}
+            maxDistance={WALL_DISTANCE - CAMERA_DISTANCE}
           />
           <ambientLight intensity={0.8} />
           <GalleryScene />


### PR DESCRIPTION
## Summary
- update gallery room controls so the camera stays a fixed distance from the wall
- add repeating wall texture from `wall.png`
- move viewer along the wall using left/right arrow keys

## Testing
- `npx biome format src/pages/DrawingsRoom.tsx --write` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862b6d265248323a27678fb2022aaf1