### PR TITLE
Improve virtual room docs

### DIFF
--- a/Agent/README.md
+++ b/Agent/README.md
@@ -6,3 +6,4 @@ This directory contains the project tasks split into independent scopes. Each fi
 - `frontend/` – Folder containing task files for each frontend section (navigation, gallery, boardgame, stories, etc.)
 - `backend.md` – Tasks covering the Node.js/Express backend and Stripe integration
 - `deployment.md` – Tasks for deploying both the frontend and backend
+- The virtual gallery room documentation is in `frontend/virtual-room.md` and includes file paths for editing the 3D scene

--- a/Agent/frontend/README.md
+++ b/Agent/frontend/README.md
@@ -7,7 +7,7 @@ This folder contains separate task lists for each major section of the frontend.
 - `cart.md` – Cart and product display functionality
 - `product-cards.md` – Shopping card component tasks
 - `gallery.md` – Virtual drawings gallery features
-- `virtual-room.md` – 3D gallery room instructions
+- `virtual-room.md` – 3D gallery room instructions and file locations for the room implementation
 - `boardgame.md` – Board Game page specifics
 - `stories.md` – Stories page features
 - `design.md` – General design improvements

--- a/Agent/frontend/virtual-room.md
+++ b/Agent/frontend/virtual-room.md
@@ -9,3 +9,14 @@ Guidelines for implementing the fullscreen 3D gallery room accessible at `/drawi
 - Duplicate wall segments horizontally so the room appears endless as the camera moves.
 - Images should load via `import.meta.glob` as in the rest of the gallery.
 - Keep the implementation lightweight and responsive.
+
+
+## File Location
+The main implementation is in `tobis-space/src/pages/DrawingsRoom.tsx`. This component sets up the React Three Fiber scene and loads the images using `../files/drawings/index.ts`.
+
+## Editing Tips
+- Start the frontend with `npm run dev` inside `tobis-space` to iterate quickly.
+- Each drawing entry is defined in `src/files/drawings/index.ts` by scanning the `drawings/` folder. Add images or adjust `info.csv` to update descriptions and prices.
+- `GallerySegment` in `DrawingsRoom.tsx` duplicates artwork groups to fake an endless corridor. Modify the `ART_SPACING` constant or the placement logic to change spacing.
+- Styles rely on Tailwind classes. Use the `min-h-screen` layout rule from the agent briefing for consistency.
+


### PR DESCRIPTION
## Summary
- expand virtual room instructions with file references and editing tips
- link to the virtual room guide from the frontend README
- mention virtual room docs in the main Agent readme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b715a96883238def4ec133915bb1