### PR TITLE
Switch drawings route to virtual room

### DIFF
--- a/Agent/frontend/gallery.md
+++ b/Agent/frontend/gallery.md
@@ -4,6 +4,6 @@
 - [x] Add modal to preview enlarged artwork
 - [x] Allow adding individual artworks to cart
 - [ ] (Later) Add hover effects or simple 3D illusion
-- [x] Add a `/drawings/room` subpage for an interactive room view
+- [x] Add a `/drawings` interactive room view
 - [x] Let visitors pan or take small steps to look around
 - [x] Keep movement minimal to stay lightweight

--- a/Agent/frontend/pages-navigation.md
+++ b/Agent/frontend/pages-navigation.md
@@ -5,6 +5,7 @@
   - `/boardgame` → Board Game section
   - `/stories` → Stories section
   - `/boardgame/updates` → Board Game updates
-  - `/drawings/room` → Walk-around view of the gallery
+  - `/drawings` → Walk-around view of the gallery
+  - `/drawings/gallery` → Grid gallery view
 - [x] Add navigation bar with active link highlighting
 - [x] Implement a **shared layout** (e.g. with `<Outlet>`)

--- a/Agent/frontend/virtual-room.md
+++ b/Agent/frontend/virtual-room.md
@@ -1,6 +1,6 @@
 # Virtual Gallery Room
 
-Guidelines for implementing the fullscreen 3D gallery room accessible at `/drawings/room`.
+Guidelines for implementing the fullscreen 3D gallery room accessible at `/drawings`.
 
 - Use **React Three Fiber** with Drei helpers.
 - Allow the camera to pan freely using `MapControls`.

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -32,8 +32,8 @@ export default function App() {
           <Route index element={<StoryOverview />} />
           <Route path=":chapterSlug" element={<Chapter />} />
         </Route>
-        <Route path="drawings" element={<Drawings />} />
-        <Route path="drawings/room" element={<DrawingsRoom />} />
+        <Route path="drawings" element={<DrawingsRoom />} />
+        <Route path="drawings/gallery" element={<Drawings />} />
         <Route path="software" element={<Software />} />
         <Route path="about" element={<About />} />
         <Route path="success" element={<CheckoutSuccess />} />

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -22,12 +22,12 @@ export default function Drawings() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="page-title">Drawings</h2>
-        <Link to="/drawings/room" className="text-blue-500 underline">
+      <header className="flex items-center justify-between mb-4">
+        <h2 className="page-title">Gallery</h2>
+        <Link to="/drawings" className="text-blue-500 underline">
           Virtual Room
         </Link>
-      </div>
+      </header>
       <select
         className="border rounded p-1 mb-4 bg-white dark:bg-gray-700 dark:text-white dark:border-gray-600"
         value={filter}

--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -3,12 +3,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { Canvas, useFrame, useLoader } from "@react-three/fiber"
 import { Html, OrbitControls } from "@react-three/drei"
-import { DoubleSide, Mesh, TextureLoader, RepeatWrapping } from "three"
+import {
+  DoubleSide,
+  Mesh,
+  TextureLoader,
+  RepeatWrapping,
+} from "three"
 import { Link } from 'react-router-dom'
 import drawings from "../files/drawings"
 import wallImg from "../assets/drawings/wall.png"
 
-const ROOM_RADIUS = 8
+const ROOM_RADIUS = 12
 const WALL_HEIGHT = 5
 
 const SHOW_THRESHOLD = 1.1
@@ -28,15 +33,17 @@ function angleDiff(a: number, b: number) {
   return Math.atan2(Math.sin(diff), Math.cos(diff))
 }
 
+const LAYERS = 3
+const ROOM_HEIGHT = LAYERS * WALL_HEIGHT
 const angleStep = (Math.PI * 2) / drawings.length
 const placements = drawings.map((_, i) => ({
   angle: i * angleStep,
-  offsetY: Math.random() * 2 - 1,
+  offsetY: Math.random() * ROOM_HEIGHT - ROOM_HEIGHT / 2,
   width: 2 + Math.random() * 2,
   height: 2 + Math.random() * 2,
 }))
 
-const CAMERA_DISTANCE = ROOM_RADIUS - 3
+const CAMERA_DISTANCE = ROOM_RADIUS - 1
 
 function ArtPlane({
   texture,
@@ -111,18 +118,49 @@ function GalleryScene({
     })
   })
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const controls = controlsRef.current
+      if (!controls) return
+      if (e.key === 'ArrowUp') {
+        controls.target.y += 0.5
+        controls.object.position.y += 0.5
+      } else if (e.key === 'ArrowDown') {
+        controls.target.y -= 0.5
+        controls.object.position.y -= 0.5
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [])
+
   wallTexture.wrapS = RepeatWrapping
   wallTexture.wrapT = RepeatWrapping
-  wallTexture.repeat.set(8, 2)
+  wallTexture.repeat.set(1, 1)
+
+  const SEGMENTS = 32
+  const wallWidth = (2 * Math.PI * ROOM_RADIUS) / SEGMENTS
 
   return (
     <group>
-      <mesh>
-        <cylinderGeometry
-          args={[ROOM_RADIUS, ROOM_RADIUS, WALL_HEIGHT, 64, 1, true]}
-        />
-        <meshBasicMaterial map={wallTexture} side={DoubleSide} />
-      </mesh>
+      {Array.from({ length: LAYERS }).map((_, layer) =>
+        Array.from({ length: SEGMENTS }).map((_, i) => {
+          const angle = (i / SEGMENTS) * Math.PI * 2
+          const x = Math.cos(angle) * ROOM_RADIUS
+          const z = Math.sin(angle) * ROOM_RADIUS
+          const y = layer * WALL_HEIGHT
+          return (
+            <mesh
+              key={`wall-${layer}-${i}`}
+              position={[x, y, z]}
+              rotation={[0, -angle - Math.PI / 2, 0]}
+            >
+              <planeGeometry args={[wallWidth, WALL_HEIGHT]} />
+              <meshBasicMaterial map={wallTexture} side={DoubleSide} />
+            </mesh>
+          )
+        }),
+      )}
       {placements.map((rand, index) => {
         const drawingIndex = mapping[index]
         if (drawingIndex == null) return null
@@ -134,7 +172,7 @@ function GalleryScene({
           <ArtPlane
             key={`${index}-${drawingIndex}`}
             position={[x, rand.offsetY, z]}
-            rotation={[0, -angle, 0]}
+            rotation={[0, -angle - Math.PI / 2, 0]}
             texture={textures[drawingIndex]}
             width={rand.width}
             height={rand.height}
@@ -150,12 +188,12 @@ export default function DrawingsRoom() {
 
   return (
     <div className="min-h-screen w-screen bg-gray-200">
-      <div className="fixed top-4 left-4 z-10 flex items-center gap-4">
-        <Link to="/drawings" className="text-blue-500 underline flex items-center">
+      <header className="fixed top-4 left-4 z-10 flex items-center gap-4">
+        <Link to="/drawings/gallery" className="text-blue-500 underline flex items-center">
           <FontAwesomeIcon icon={faArrowLeft} className="mr-1" /> Back to gallery
         </Link>
         <h2 className="page-title text-white">Virtual Room</h2>
-      </div>
+      </header>
 
       <Canvas
         className="w-full h-full"


### PR DESCRIPTION
## Summary
- make the virtual room the main drawings page
- add headers to gallery and virtual room
- expand room radius and rotate art so it lies flat on walls
- allow vertical camera movement with arrow keys
- stack wall layers and generate walls dynamically
- update docs for new paths

## Testing
- `npm --prefix tobis-space run biome` *(fails: 403 Forbidden)*
- `npm --prefix tobis-space run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6862be8b8a088323a07fa117e7fbe6d8