### PR TITLE
Disable zoom via mouse in virtual room

### DIFF
--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -416,7 +416,7 @@ export default function DrawingsRoom() {
             target={[0, 1.5, 0]}
             enableRotate={false}
             enablePan
-            enableZoom
+            enableZoom={false}
             enableDamping
             dampingFactor={0.1}
           />


### PR DESCRIPTION
## Summary
- prevent zooming the 3D gallery room with the mouse

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863d0e0bbf48323b780b701600a2d99