### PR TITLE
Improve gallery interactions

### DIFF
--- a/tobis-space/src/components/ImageModal.tsx
+++ b/tobis-space/src/components/ImageModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faMinus, faPlus, faXmark } from "@fortawesome/free-solid-svg-icons"
+import Button from "./Button"
+import { useCart } from "../contexts/CartContext"
+import type { Drawing } from "../files/drawings"
+
+export default function ImageModal({ art, onClose }: { art: Drawing; onClose: () => void }) {
+  const { addItem, items } = useCart()
+  const [zoom, setZoom] = useState(1)
+  const inCart = items.some((i) => i.id === art.id)
+  const canAdd = art.multiple || !inCart
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="relative max-w-md w-full rounded bg-white p-4 text-black dark:bg-gray-800 dark:text-white">
+        <button
+          aria-label="Close"
+          className="absolute right-2 top-2 text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white"
+          onClick={onClose}
+        >
+          <FontAwesomeIcon icon={faXmark} />
+        </button>
+        <div className="mb-2 flex justify-center overflow-auto" style={{ maxHeight: "60vh" }}>
+          <img
+            src={art.image}
+            alt={art.name}
+            className="object-contain"
+            style={{ transform: `scale(${zoom})`, transformOrigin: "center" }}
+          />
+        </div>
+        <div className="mb-2 flex justify-center gap-2">
+          <button
+            aria-label="Zoom in"
+            className="rounded bg-gray-200 p-1 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+            onClick={() => setZoom(Math.min(3, zoom + 0.25))}
+          >
+            <FontAwesomeIcon icon={faPlus} />
+          </button>
+          <button
+            aria-label="Zoom out"
+            className="rounded bg-gray-200 p-1 text-black hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
+            onClick={() => setZoom(Math.max(1, zoom - 0.25))}
+          >
+            <FontAwesomeIcon icon={faMinus} />
+          </button>
+        </div>
+        <h3 className="text-center text-lg font-semibold">{art.name}</h3>
+        <p className="mb-1 text-center">{art.description}</p>
+        <p className="mb-2 text-center font-bold">{art.price.toFixed(2)} €</p>
+        <div className="flex justify-center gap-2">
+          <Button
+            onClick={() =>
+              addItem({ id: art.id, name: art.name, price: art.price, multiple: art.multiple })
+            }
+            disabled={!canAdd}
+          >
+            {inCart && !art.multiple ? "Added" : "Add to Cart"}
+          </Button>
+          <Button className="bg-gray-300 text-black hover:bg-gray-400" onClick={onClose}>
+            <FontAwesomeIcon icon={faXmark} className="mr-1" /> Close
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,17 +1,18 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faXmark } from "@fortawesome/free-solid-svg-icons"
 import Card from "../components/Card"
 import Button from "../components/Button"
+import ImageModal from "../components/ImageModal"
 import { useCart } from "../contexts/CartContext"
-import drawings, { categories, type Drawing } from '../files/drawings'
+import drawings, { categories, type Drawing } from "../files/drawings"
 
 const allCategory = "all"
 
 
 export default function Drawings() {
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useState<Drawing | null>(null)
   const [filter, setFilter] = useState(allCategory)
   const { addItem, items } = useCart()
 
@@ -34,52 +35,17 @@ export default function Drawings() {
 
   const renderCard = (art: Drawing) => {
     const inCart = items.some((i) => i.id === art.id)
-    const canAdd = art.multiple || !inCart
     return (
-      <Card
-        key={art.id}
-        className={inCart ? 'bg-green-200 dark:bg-green-900' : ''}
-      >
-        {selected === art.id ? (
-          <div className="w-48 h-48 flex flex-col items-center justify-center text-center space-y-2">
-            <p className="font-semibold">{art.name}</p>
-            <p className="text-sm">{art.description}</p>
-            <p className="font-bold">{art.price.toFixed(2)} €</p>
-            <div className="flex gap-2">
-              <Button
-                onClick={() =>
-                  addItem({
-                    id: art.id,
-                    name: art.name,
-                    price: art.price,
-                    multiple: art.multiple,
-                  })
-                }
-                disabled={!canAdd}
-              >
-                {inCart && !art.multiple ? 'Added' : 'Add to Cart'}
-              </Button>
-              <Button
-                className="bg-gray-300 text-black hover:bg-gray-400"
-                onClick={() => setSelected(null)}
-              >
-                <FontAwesomeIcon icon={faXmark} className="mr-1" /> Close
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
-            <img
-              src={art.image}
-              alt={art.name}
-              className="w-48 h-48 object-contain mb-2 cursor-pointer"
-              onClick={() => setSelected(art.id)}
-            />
-            <p className="text-center">{art.name}</p>
-            {inCart && !art.multiple && (
-              <p className="text-sm text-green-600">Added to cart</p>
-            )}
-          </>
+      <Card key={art.id} className={inCart ? "bg-green-200 dark:bg-green-900" : ""}>
+        <img
+          src={art.image}
+          alt={art.name}
+          className="mb-2 h-48 w-48 cursor-pointer object-contain"
+          onClick={() => setSelected(art)}
+        />
+        <p className="text-center">{art.name}</p>
+        {inCart && !art.multiple && (
+          <p className="text-sm text-green-600">Added to cart</p>
         )}
       </Card>
     )
@@ -121,6 +87,7 @@ export default function Drawings() {
           {filtered.map(renderCard)}
         </div>
       )}
+      {selected && <ImageModal art={selected} onClose={() => setSelected(null)} />}
     </div>
   )
 }

--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -443,12 +443,12 @@ export default function DrawingsRoom() {
 
   return (
     <div className="min-h-screen w-screen bg-gray-200">
-      <header className="fixed top-4 left-4 z-10 flex items-center gap-4">
-        <Link to="/drawings/gallery" className="text-blue-500 underline flex items-center">
-          <FontAwesomeIcon icon={faArrowLeft} className="mr-1" /> Back to gallery
+      <div className="sticky top-16 z-30 mb-4 flex items-center justify-between gap-4 rounded border border-gray-300 bg-gray-200/70 p-2 backdrop-blur dark:border-gray-600 dark:bg-gray-700/70">
+        <h2 className="page-title m-0">Virtual Room</h2>
+        <Link to="/drawings/gallery" className="btn">
+          <FontAwesomeIcon icon={faArrowRight} className="mr-1" /> Gallery
         </Link>
-        <h2 className="page-title text-white">Virtual Room</h2>
-      </header>
+      </div>
 
       <Canvas
         className="w-full h-full"


### PR DESCRIPTION
## Summary
- add `ImageModal` component for artwork popups with zoom controls
- switch Drawings gallery to use the new modal
- restyle Virtual Room toolbar with bordered sticky bar and new navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863d94a1f1c832393e0435900da9c7e