### PR TITLE
Fix incorrect texture typing in DrawingsRoom

### DIFF
--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -24,6 +24,7 @@ import {
   RepeatWrapping,
   TextureLoader,
   Vector3,
+  type Texture,
 } from "three"
 import { Link } from "react-router-dom"
 import drawings from "../files/drawings"
@@ -109,7 +110,7 @@ function ArtPlane({
   height,
   ...props
 }: {
-  texture: string
+  texture: Texture
   width: number
   height: number
 } & ThreeElements['mesh']) {


### PR DESCRIPTION
## Summary
- import `Texture` type from Three.js
- type `texture` prop of `ArtPlane` as `Texture`

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom', 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6863eaec85c88323adf30242aeba1412