### PR TITLE
Fix gallery zoom replacing images

### DIFF
--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -180,8 +180,6 @@ function GalleryScene({
   }, [controlsRef, showRange])
 
   useEffect(() => {
-    itemsRef.current.clear()
-    indexRef.current = 0
     ensureGrid()
   }, [ensureGrid])
 


### PR DESCRIPTION
## Summary
- keep the current grid when adjusting zoom in `DrawingsRoom`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6864080cbc2083238f957ffdc0684a10