### PR TITLE
Improve idle detection in virtual room

### DIFF
--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -73,10 +73,12 @@ function GalleryScene({
   controlsRef,
   move,
   zoom,
+  markInteraction,
 }: {
   controlsRef: React.RefObject<any>
   move: (dx: number, dy: number) => void
   zoom: number
+  markInteraction: () => void
 }) {
   const textures = useLoader(TextureLoader, drawings.map((d) => d.image))
   const wallTexture = useLoader(TextureLoader, wallImg)
@@ -110,6 +112,7 @@ function GalleryScene({
         x: e.clientX - rect.left,
         y: e.clientY - rect.top,
       }
+      markInteraction()
     }
     const handleLeave = () => {
       pointerRef.current = { x: -1, y: -1 }
@@ -120,7 +123,7 @@ function GalleryScene({
       gl.domElement.removeEventListener('mousemove', handleMove)
       gl.domElement.removeEventListener('mouseleave', handleLeave)
     }
-  }, [gl])
+  }, [gl, markInteraction])
 
   function nextIndex() {
     const idx = indexRef.current % drawings.length
@@ -194,6 +197,7 @@ function GalleryScene({
     const edge = 50
     const moveStep = 0.2
     if (pointer.x >= 0 && pointer.y >= 0) {
+      markInteraction()
       if (pointer.x < edge) {
         controls.target.x -= moveStep
         controls.object.position.x -= moveStep
@@ -353,10 +357,14 @@ export default function DrawingsRoom() {
 
   const startContinuousMove = useCallback(
     (dx: number, dy: number) => {
+      markInteraction()
       move(dx, dy)
-      moveInterval.current = setInterval(() => move(dx, dy), 100)
+      moveInterval.current = setInterval(() => {
+        markInteraction()
+        move(dx, dy)
+      }, 100)
     },
-    [move],
+    [move, markInteraction],
   )
 
   const stopContinuousMove = useCallback(() => {
@@ -460,7 +468,12 @@ export default function DrawingsRoom() {
             touches={{ ONE: TOUCH.PAN, TWO: TOUCH.PAN }}
           />
           <ambientLight intensity={0.8} />
-          <GalleryScene controlsRef={controlsRef} move={move} zoom={zoom} />
+          <GalleryScene
+            controlsRef={controlsRef}
+            move={move}
+            zoom={zoom}
+            markInteraction={markInteraction}
+          />
         </Suspense>
       </Canvas>
       <div className="fixed bottom-4 right-4 z-20 flex flex-col items-center space-y-2 text-white">


### PR DESCRIPTION
## Summary
- pass `markInteraction` to `GalleryScene`
- register mouse movement as interaction
- keep interaction active while moving camera via UI buttons

## Testing
- `npm run build` *(fails: Cannot find module errors)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686409e3799883239d0be7e69cf6c035