### PR TITLE
Fix router base path

### DIFF
--- a/tobis-space/src/main.tsx
+++ b/tobis-space/src/main.tsx
@@ -7,9 +7,11 @@ import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 import App from './App'
 
+const basename = import.meta.env.BASE_URL
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <ThemeProvider>
         <CartProvider>
           <ErrorBoundary>


### PR DESCRIPTION
## Summary
- fix the Router basename to use `import.meta.env.BASE_URL`

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68640a8374488323bc0b86c6677477a8