### PR TITLE
Add Tailwind-only scrolling room

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -11,6 +11,7 @@ import CheckoutCancel from './pages/CheckoutCancel'
 import CheckoutSuccess from './pages/CheckoutSuccess'
 import Drawings from './pages/Drawings'
 import DrawingsRoom from './pages/DrawingsRoom'
+import DrawingsScrollRoom from './pages/DrawingsScrollRoom'
 import Home from './pages/Home'
 import Stories from './pages/Stories'
 import StoryOverview from './pages/StoryOverview'
@@ -33,6 +34,7 @@ export default function App() {
           <Route path=":chapterSlug" element={<Chapter />} />
         </Route>
         <Route path="drawings" element={<DrawingsRoom />} />
+        <Route path="drawings/scroll" element={<DrawingsScrollRoom />} />
         <Route path="drawings/gallery" element={<Drawings />} />
         <Route path="software" element={<Software />} />
         <Route path="about" element={<About />} />

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -54,7 +54,10 @@ export default function Drawings() {
         <div className="flex items-center gap-4">
           <h2 className="page-title m-0">Gallery</h2>
           <Link to="/drawings" className="text-blue-500 underline">
-            Virtual Room
+            3D Room
+          </Link>
+          <Link to="/drawings/scroll" className="text-blue-500 underline">
+            Scrolling Room
           </Link>
         </div>
         <select

--- a/tobis-space/src/pages/DrawingsRoom.tsx
+++ b/tobis-space/src/pages/DrawingsRoom.tsx
@@ -425,14 +425,23 @@ export default function DrawingsRoom() {
   return (
     <div className="w-full h-screen pb-5 bg-gray-200">
       <div className="sticky top-16 z-30 mb-4 flex items-center justify-between gap-4 rounded border border-gray-300 bg-gray-200/70 p-2 backdrop-blur dark:border-gray-600 dark:bg-gray-700/70">
-        <h2 className="page-title m-0">Virtual Room</h2>
-        <Link
-          to="/drawings/gallery"
-          className="btn bg-brand-neon px-6 py-3 text-lg hover:bg-brand"
-        >
-          To the gallery
-          <FontAwesomeIcon icon={faArrowRight} className="ml-2" />
-        </Link>
+        <h2 className="page-title m-0">3D Room</h2>
+        <div className="flex gap-2">
+          <Link
+            to="/drawings/scroll"
+            className="btn bg-brand-neon px-6 py-3 text-lg hover:bg-brand"
+          >
+            Scroll Room
+            <FontAwesomeIcon icon={faArrowRight} className="ml-2" />
+          </Link>
+          <Link
+            to="/drawings/gallery"
+            className="btn bg-brand-neon px-6 py-3 text-lg hover:bg-brand"
+          >
+            Gallery
+            <FontAwesomeIcon icon={faArrowRight} className="ml-2" />
+          </Link>
+        </div>
       </div>
 
       <Canvas

--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons'
+import { Link } from 'react-router-dom'
+import drawings from '../files/drawings'
+
+export default function DrawingsScrollRoom() {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const scroll = (dir: number) => {
+    containerRef.current?.scrollBy({ left: dir, behavior: 'smooth' })
+  }
+
+  return (
+    <div className="w-full min-h-screen bg-gray-200">
+      <div className="sticky top-16 z-30 mb-4 flex items-center justify-between gap-4 rounded border border-gray-300 bg-gray-200/70 p-2 backdrop-blur dark:border-gray-600 dark:bg-gray-700/70">
+        <h2 className="page-title m-0">Scrolling Room</h2>
+        <div className="flex gap-4">
+          <Link to="/drawings" className="text-blue-500 underline">
+            3D Room
+          </Link>
+          <Link to="/drawings/gallery" className="text-blue-500 underline">
+            Gallery
+          </Link>
+        </div>
+      </div>
+      <div className="relative">
+        <div
+          ref={containerRef}
+          className="flex overflow-x-scroll scroll-smooth snap-x snap-mandatory min-h-screen pb-16"
+        >
+          {drawings.map((d) => (
+            <div
+              key={d.id}
+              className="flex-shrink-0 snap-center w-screen flex flex-col items-center justify-center px-4"
+            >
+              <img src={d.image} alt={d.name} className="h-80 object-contain mb-2" />
+              <p>{d.name}</p>
+            </div>
+          ))}
+        </div>
+        <button
+          aria-label="Move left"
+          className="absolute left-4 top-1/2 -translate-y-1/2 bg-gray-700/40 text-white p-2 rounded hover:bg-gray-700/60"
+          onClick={() => scroll(-300)}
+        >
+          <FontAwesomeIcon icon={faArrowLeft} />
+        </button>
+        <button
+          aria-label="Move right"
+          className="absolute right-4 top-1/2 -translate-y-1/2 bg-gray-700/40 text-white p-2 rounded hover:bg-gray-700/60"
+          onClick={() => scroll(300)}
+        >
+          <FontAwesomeIcon icon={faArrowRight} />
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add alternative virtual room using Tailwind only
- link new room from gallery and 3D room
- route `/drawings/scroll` to new page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686426a529c8832388cc735d12b9a021