### PR TITLE
Enhance scrolling room view

### DIFF
--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -1,18 +1,64 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
 import drawings from '../files/drawings'
+import wallImg from '../assets/drawings/wall.png'
 
 export default function DrawingsScrollRoom() {
   const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    let active = true
+    const step = 1
+    let restartTimer: NodeJS.Timeout | null = null
+
+    const start = () => {
+      active = true
+    }
+
+    const stop = () => {
+      active = false
+      if (restartTimer) clearTimeout(restartTimer)
+      restartTimer = setTimeout(start, 5000)
+    }
+
+    const interval = setInterval(() => {
+      if (!active) return
+      if (el.scrollLeft >= el.scrollWidth - el.clientWidth) {
+        el.scrollTo({ left: 0 })
+      } else {
+        el.scrollLeft += step
+      }
+    }, 20)
+
+    el.addEventListener('mousedown', stop)
+    el.addEventListener('touchstart', stop)
+
+    return () => {
+      clearInterval(interval)
+      if (restartTimer) clearTimeout(restartTimer)
+      el.removeEventListener('mousedown', stop)
+      el.removeEventListener('touchstart', stop)
+    }
+  }, [])
 
   const scroll = (dir: number) => {
     containerRef.current?.scrollBy({ left: dir, behavior: 'smooth' })
   }
 
   return (
-    <div className="w-full min-h-screen bg-gray-200">
+    <div
+      className="w-full min-h-screen bg-gray-200"
+      style={{
+        backgroundImage: `url(${wallImg})`,
+        backgroundSize: '200px',
+        backgroundRepeat: 'repeat',
+      }}
+    >
       <div className="sticky top-16 z-30 mb-4 flex items-center justify-between gap-4 rounded border border-gray-300 bg-gray-200/70 p-2 backdrop-blur dark:border-gray-600 dark:bg-gray-700/70">
         <h2 className="page-title m-0">Scrolling Room</h2>
         <div className="flex gap-4">
@@ -27,15 +73,12 @@ export default function DrawingsScrollRoom() {
       <div className="relative">
         <div
           ref={containerRef}
-          className="flex overflow-x-scroll scroll-smooth snap-x snap-mandatory min-h-screen pb-16"
+          className="grid grid-flow-col auto-cols-max grid-rows-1 sm:grid-rows-2 lg:grid-rows-3 gap-2 overflow-x-scroll scroll-smooth min-h-screen pb-16"
         >
           {drawings.map((d) => (
-            <div
-              key={d.id}
-              className="flex-shrink-0 snap-center w-screen flex flex-col items-center justify-center px-4"
-            >
-              <img src={d.image} alt={d.name} className="h-80 object-contain mb-2" />
-              <p>{d.name}</p>
+            <div key={d.id} className="w-48 flex flex-col items-center px-1">
+              <img src={d.image} alt={d.name} className="h-48 w-48 object-contain mb-1" />
+              <p className="text-center text-sm">{d.name}</p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- enhance drawings scrolling room layout
- render 1-3 rows based on screen size
- apply wall texture background
- add auto scrolling that pauses on interaction and resumes after 5s

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686428f0e268832384c4e17cb273847f