### PR TITLE
Improve scrolling room layout

### DIFF
--- a/tobis-space/src/hooks/useDrawingModal.tsx
+++ b/tobis-space/src/hooks/useDrawingModal.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+import type { Drawing } from '../files/drawings'
+import ImageModal from '../components/ImageModal'
+
+export default function useDrawingModal() {
+  const [selected, setSelected] = useState<Drawing | null>(null)
+  const modal =
+    selected !== null ? (
+      <ImageModal art={selected} onClose={() => setSelected(null)} />
+    ) : null
+  return {
+    open: setSelected,
+    modal,
+  }
+}
+

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,16 +1,16 @@
 import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import Card from "../components/Card"
-import ImageModal from "../components/ImageModal"
 import { useCart } from "../contexts/CartContext"
 import drawings, { categories, type Drawing } from "../files/drawings"
+import useDrawingModal from "../hooks/useDrawingModal"
 
 const allCategory = "all"
 
 
 export default function Drawings() {
-  const [selected, setSelected] = useState<Drawing | null>(null)
   const [filter, setFilter] = useState(allCategory)
+  const { open: openModal, modal } = useDrawingModal()
   const { items } = useCart()
 
   const sortedCategories = useMemo(() => [...categories].sort(), [])
@@ -38,7 +38,7 @@ export default function Drawings() {
           src={art.image}
           alt={art.name}
           className="mb-2 h-48 w-48 cursor-pointer object-contain"
-          onClick={() => setSelected(art)}
+          onClick={() => openModal(art)}
         />
         <p className="text-center">{art.name}</p>
         {inCart && !art.multiple && (
@@ -87,7 +87,8 @@ export default function Drawings() {
           {filtered.map(renderCard)}
         </div>
       )}
-      {selected && <ImageModal art={selected} onClose={() => setSelected(null)} />}
+      {modal}
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- export `useDrawingModal` hook to reuse ImageModal logic
- show drawings in gallery using new modal hook
- enlarge images in the scrolling room and add shadow
- implement endless scrolling and matching wall movement
- open image modal from the scrolling room

## Testing
- `npx biome format src/hooks/useDrawingModal.tsx src/pages/Drawings.tsx src/pages/DrawingsScrollRoom.tsx -w` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686430c72a3083238fa45ddc5107cb47