### PR TITLE
Update scroll room category order

### DIFF
--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -2,15 +2,81 @@ import { useEffect, useRef, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
-import drawings from '../files/drawings'
+import drawings, { categories, type Drawing } from '../files/drawings'
 import wallImg from '../assets/drawings/wall.png'
 import useDrawingModal from '../hooks/useDrawingModal'
+
+function useRowCount() {
+  const getRows = () => {
+    if (window.matchMedia('(min-width: 1024px)').matches) return 3
+    if (window.matchMedia('(min-width: 640px)').matches) return 2
+    return 1
+  }
+  const [rows, setRows] = useState<number>(() => getRows())
+  useEffect(() => {
+    const update = () => setRows(getRows())
+    const mLg = window.matchMedia('(min-width: 1024px)')
+    const mSm = window.matchMedia('(min-width: 640px)')
+    mLg.addEventListener('change', update)
+    mSm.addEventListener('change', update)
+    return () => {
+      mLg.removeEventListener('change', update)
+      mSm.removeEventListener('change', update)
+    }
+  }, [])
+  return rows
+}
 
 export default function DrawingsScrollRoom() {
   const containerRef = useRef<HTMLDivElement>(null)
   const { open: openModal, modal } = useDrawingModal()
-  const [items, setItems] = useState([...drawings])
+
+  type RowItem =
+    | { type: 'label'; category: string }
+    | { type: 'drawing'; drawing: Drawing }
+
+  const sortedCategories = [...categories].sort()
+
+  const drawingsByCat: Record<string, Drawing[]> = {}
+  for (const cat of sortedCategories) {
+    drawingsByCat[cat] = drawings
+      .filter((d) => d.category === cat)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  const rows = useRowCount()
+
+  const makeCycle = (start: number) => {
+    const arr: RowItem[] = []
+    for (let i = 0; i < sortedCategories.length; i++) {
+      const cat = sortedCategories[(start + i) % sortedCategories.length]
+      arr.push({ type: 'label', category: cat })
+      arr.push(
+        ...drawingsByCat[cat].map((d) => ({ type: 'drawing', drawing: d }))
+      )
+    }
+    return arr
+  }
+
+  const makeRows = () => {
+    const sequences = Array.from({ length: rows }, (_, i) => makeCycle(i))
+    const maxLen = Math.max(...sequences.map((s) => s.length))
+    const result: RowItem[] = []
+    for (let col = 0; col < maxLen; col++) {
+      for (let row = 0; row < rows; row++) {
+        const item = sequences[row][col]
+        if (item) result.push(item)
+      }
+    }
+    return result
+  }
+
+  const [items, setItems] = useState<RowItem[]>(makeRows())
   const [bgPos, setBgPos] = useState(0)
+
+  useEffect(() => {
+    setItems(makeRows())
+  }, [rows])
 
   useEffect(() => {
     const el = containerRef.current
@@ -33,7 +99,7 @@ export default function DrawingsScrollRoom() {
     const onScroll = () => {
       setBgPos(el.scrollLeft)
       if (el.scrollLeft >= el.scrollWidth - el.clientWidth - 200) {
-        setItems((prev) => [...prev, ...drawings])
+        setItems((prev) => [...prev, ...makeRows()])
       }
     }
 
@@ -85,17 +151,29 @@ export default function DrawingsScrollRoom() {
           ref={containerRef}
           className="grid grid-flow-col auto-cols-max grid-rows-1 sm:grid-rows-2 lg:grid-rows-3 gap-4 overflow-x-scroll scroll-smooth min-h-screen pb-16"
         >
-          {items.map((d, idx) => (
-            <div key={`${d.id}-${idx}`} className="w-60 flex flex-col items-center px-2">
-              <img
-                src={d.image}
-                alt={d.name}
-                className="mb-2 h-60 w-60 cursor-pointer object-contain shadow-lg"
-                onClick={() => openModal(d)}
-              />
-              <p className="text-center text-base">{d.name}</p>
-            </div>
-          ))}
+          {items.map((item, idx) =>
+            item.type === 'label' ? (
+              <div
+                key={`label-${item.category}-${idx}`}
+                className="flex items-center justify-center w-60 text-lg font-semibold"
+              >
+                {item.category}
+              </div>
+            ) : (
+              <div
+                key={`${item.drawing.id}-${idx}`}
+                className="w-60 flex flex-col items-center px-2"
+              >
+                <img
+                  src={item.drawing.image}
+                  alt={item.drawing.name}
+                  className="mb-2 h-60 w-60 cursor-pointer object-contain shadow-lg"
+                  onClick={() => openModal(item.drawing)}
+                />
+                <p className="text-center text-base">{item.drawing.name}</p>
+              </div>
+            )
+          )}
         </div>
         <button
           aria-label="Move left"


### PR DESCRIPTION
## Summary
- organize scroll room items by category
- add responsive hook to detect row count
- support endless scroll with grouped rows

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module 'react-router-dom' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686434f985b48323a505b99237ba8924