### PR TITLE
Add checkout page for address entry

### DIFF
--- a/tobis-space/server/index.js
+++ b/tobis-space/server/index.js
@@ -11,11 +11,13 @@ const stripe = new Stripe(process.env.STRIPE_SECRET || '', { apiVersion: '2024-0
 
 app.post('/create-checkout-session', async (req, res) => {
   try {
+    const { items, address } = req.body
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
-      line_items: req.body.items,
+      line_items: items,
       success_url: `${req.headers.origin}/success`,
       cancel_url: `${req.headers.origin}/cancel`,
+      metadata: address,
     })
     res.json({ url: session.url })
   } catch (err) {

--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -12,6 +12,7 @@ import CheckoutSuccess from './pages/CheckoutSuccess'
 import Drawings from './pages/Drawings'
 import DrawingsRoom from './pages/DrawingsRoom'
 import DrawingsScrollRoom from './pages/DrawingsScrollRoom'
+import Checkout from './pages/Checkout'
 import Home from './pages/Home'
 import Stories from './pages/Stories'
 import StoryOverview from './pages/StoryOverview'
@@ -38,6 +39,7 @@ export default function App() {
         <Route path="drawings/gallery" element={<Drawings />} />
         <Route path="software" element={<Software />} />
         <Route path="about" element={<About />} />
+        <Route path="checkout" element={<Checkout />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />
       </Route>

--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -4,22 +4,13 @@ import {
   faTrash,
   faXmark,
 } from '@fortawesome/free-solid-svg-icons'
-import { useCart, type CartItem } from '../contexts/CartContext'
+import { useCart } from '../contexts/CartContext'
+import { useNavigate } from 'react-router-dom'
 
-async function checkout(items: CartItem[]) {
-  const res = await fetch('/create-checkout-session', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ items }),
-  })
-  const data = await res.json()
-  if (data.url) {
-    window.location.href = data.url
-  }
-}
 
 export default function Cart() {
   const { items, removeItem, clear } = useCart()
+  const navigate = useNavigate()
 
   if (items.length === 0) return <p>Your cart is empty.</p>
 
@@ -45,7 +36,10 @@ export default function Cart() {
             <FontAwesomeIcon icon={faTrash} className="mr-1" /> Clear
           </button>
         </div>
-        <button onClick={() => checkout(items)} className="btn bg-green-600 hover:bg-green-700">
+        <button
+          onClick={() => navigate('/checkout')}
+          className="btn bg-green-600 hover:bg-green-700"
+        >
           <FontAwesomeIcon icon={faCreditCard} className="mr-1" /> Buy
         </button>
       </div>

--- a/tobis-space/src/pages/Checkout.tsx
+++ b/tobis-space/src/pages/Checkout.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useCart, type CartItem } from '../contexts/CartContext'
+
+interface Address {
+  name: string
+  street: string
+  city: string
+  zip: string
+  country: string
+}
+
+async function checkout(items: CartItem[], address: Address) {
+  const res = await fetch('/create-checkout-session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items, address }),
+  })
+  const data = await res.json()
+  if (data.url) {
+    window.location.href = data.url
+  }
+}
+
+export default function Checkout() {
+  const { items, clear } = useCart()
+  const navigate = useNavigate()
+  const [address, setAddress] = useState<Address>({
+    name: '',
+    street: '',
+    city: '',
+    zip: '',
+    country: '',
+  })
+
+  if (items.length === 0) return <p>Your cart is empty.</p>
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setAddress((a) => ({ ...a, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await checkout(items, address)
+    clear()
+    navigate('/success')
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto flex max-w-md flex-col space-y-4"
+    >
+      <h2 className="page-title">Checkout</h2>
+      <input
+        required
+        name="name"
+        placeholder="Name"
+        value={address.name}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      />
+      <input
+        required
+        name="street"
+        placeholder="Street"
+        value={address.street}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      />
+      <input
+        required
+        name="city"
+        placeholder="City"
+        value={address.city}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      />
+      <input
+        required
+        name="zip"
+        placeholder="ZIP"
+        value={address.zip}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      />
+      <input
+        required
+        name="country"
+        placeholder="Country"
+        value={address.country}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      />
+      <button type="submit" className="btn bg-green-600 hover:bg-green-700">
+        Continue to Payment
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- create `Checkout` page with form to collect address before payment
- route `/checkout` to new page
- change cart buy button to navigate to checkout
- store address metadata in Stripe session

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a2b6c03288323bfb8a02ef304d434