### PR TITLE
Toggle add/remove buttons

### DIFF
--- a/tobis-space/src/components/ImageModal.tsx
+++ b/tobis-space/src/components/ImageModal.tsx
@@ -6,7 +6,7 @@ import { useCart } from "../contexts/CartContext"
 import type { Drawing } from "../files/drawings"
 
 export default function ImageModal({ art, onClose }: { art: Drawing; onClose: () => void }) {
-  const { addItem, items } = useCart()
+  const { addItem, removeItem, items } = useCart()
   const [zoom, setZoom] = useState(1)
   const handleZoomIn = () => setZoom((z) => Math.min(3, z + 0.25))
   const handleZoomOut = () => setZoom((z) => Math.max(1, z - 0.25))
@@ -56,14 +56,18 @@ export default function ImageModal({ art, onClose }: { art: Drawing; onClose: ()
         <p className="mb-1 text-center">{art.description}</p>
         <p className="mb-2 text-center font-bold">{art.price.toFixed(2)} €</p>
         <div className="flex justify-center gap-2">
-          <Button
-            onClick={() =>
-              addItem({ id: art.id, name: art.name, price: art.price, multiple: art.multiple })
-            }
-            disabled={!canAdd}
-          >
-            {inCart && !art.multiple ? "Added" : "Add to Cart"}
-          </Button>
+          {inCart && !art.multiple ? (
+            <Button onClick={() => removeItem(art.id)}>Remove</Button>
+          ) : (
+            <Button
+              onClick={() =>
+                addItem({ id: art.id, name: art.name, price: art.price, multiple: art.multiple })
+              }
+              disabled={!canAdd}
+            >
+              Add to Cart
+            </Button>
+          )}
           <Button className="bg-gray-300 text-black hover:bg-gray-400" onClick={onClose}>
             <FontAwesomeIcon icon={faXmark} className="mr-1" /> Close
           </Button>

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react"
 import { Link } from "react-router-dom"
 import Card from "../components/Card"
+import Button from "../components/Button"
 import { useCart } from "../contexts/CartContext"
 import drawings, { categories, type Drawing } from "../files/drawings"
 import useDrawingModal from "../hooks/useDrawingModal"
@@ -11,7 +12,7 @@ const allCategory = "all"
 export default function Drawings() {
   const [filter, setFilter] = useState(allCategory)
   const { open: openModal, modal } = useDrawingModal()
-  const { items } = useCart()
+  const { addItem, removeItem, items } = useCart()
 
   const sortedCategories = useMemo(() => [...categories].sort(), [])
   const drawingsByCat = useMemo(() => {
@@ -32,6 +33,11 @@ export default function Drawings() {
 
   const renderCard = (art: Drawing) => {
     const inCart = items.some((i) => i.id === art.id)
+    const handleClick = () => {
+      if (inCart && !art.multiple) removeItem(art.id)
+      else
+        addItem({ id: art.id, name: art.name, price: art.price, multiple: art.multiple })
+    }
     return (
       <Card key={art.id} className={inCart ? "bg-green-200 dark:bg-green-900" : ""}>
         <img
@@ -41,9 +47,9 @@ export default function Drawings() {
           onClick={() => openModal(art)}
         />
         <p className="text-center">{art.name}</p>
-        {inCart && !art.multiple && (
-          <p className="text-sm text-green-600">Added to cart</p>
-        )}
+        <Button className="mt-2" onClick={handleClick}>
+          {inCart && !art.multiple ? "Remove" : "Add to Cart"}
+        </Button>
       </Card>
     )
   }

--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import drawings, { categories, type Drawing } from '../files/drawings'
 import wallImg from '../assets/drawings/wall.png'
 import useDrawingModal from '../hooks/useDrawingModal'
+import Button from '../components/Button'
 import { useCart } from '../contexts/CartContext'
 
 function useRowCount() {
@@ -31,7 +32,7 @@ function useRowCount() {
 export default function DrawingsScrollRoom() {
   const containerRef = useRef<HTMLDivElement>(null)
   const { open: openModal, modal } = useDrawingModal()
-  const { items: cartItems } = useCart()
+  const { items: cartItems, addItem, removeItem } = useCart()
 
   type RowItem =
     | { type: 'label'; category: string }
@@ -177,9 +178,23 @@ export default function DrawingsScrollRoom() {
                   onClick={() => openModal(item.drawing)}
                 />
                 <p className="inline-block rounded bg-gray-800/90 px-2 py-0.5 text-sm text-white shadow">{item.drawing.name}</p>
-                {cartItems.some((i) => i.id === item.drawing.id) && !item.drawing.multiple && (
-                  <p className="text-sm text-green-600">Added to cart</p>
-                )}
+                <Button
+                  className="mt-1"
+                  onClick={() =>
+                    cartItems.some((i) => i.id === item.drawing.id) && !item.drawing.multiple
+                      ? removeItem(item.drawing.id)
+                      : addItem({
+                          id: item.drawing.id,
+                          name: item.drawing.name,
+                          price: item.drawing.price,
+                          multiple: item.drawing.multiple,
+                        })
+                  }
+                >
+                  {cartItems.some((i) => i.id === item.drawing.id) && !item.drawing.multiple
+                    ? 'Remove'
+                    : 'Add to Cart'}
+                </Button>
               </div>
             )
           )}


### PR DESCRIPTION
## Summary
- switch Add to Cart buttons to a Remove option when items are already in the cart
- offer add/remove controls directly on gallery cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_686a8769d19483239b8dc613c7956219