### PR TITLE
Fix union typing in DrawingsScrollRoom

### DIFF
--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -55,7 +55,10 @@ export default function DrawingsScrollRoom() {
       const cat = sortedCategories[(start + i) % sortedCategories.length]
       arr.push({ type: 'label', category: cat })
       arr.push(
-        ...drawingsByCat[cat].map((d) => ({ type: 'drawing', drawing: d }))
+        ...drawingsByCat[cat].map<RowItem>((d) => ({
+          type: 'drawing',
+          drawing: d,
+        }))
       )
     }
     return arr


### PR DESCRIPTION
## Summary
- fix RowItem map type in DrawingsScrollRoom

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686b5ec8b68483238d7c2e499ce43122