### PR TITLE
Add lazy loading for images

### DIFF
--- a/tobis-space/src/components/ImageModal.tsx
+++ b/tobis-space/src/components/ImageModal.tsx
@@ -26,6 +26,7 @@ export default function ImageModal({ art, onClose }: { art: Drawing; onClose: ()
           <img
             src={art.image}
             alt={art.name}
+            loading="lazy"
             className="cursor-zoom-in object-contain"
             style={{ transform: `scale(${zoom})`, transformOrigin: "center" }}
             onClick={handleZoomIn}

--- a/tobis-space/src/pages/BoardGameUpdates.tsx
+++ b/tobis-space/src/pages/BoardGameUpdates.tsx
@@ -24,7 +24,12 @@ export default function BoardGameUpdates() {
             <h4 className="font-semibold">
               {u.title} ({u.version})
             </h4>
-            <img src={u.image} alt={u.title} className="my-2 w-full max-w-xs" />
+            <img
+              src={u.image}
+              alt={u.title}
+              loading="lazy"
+              className="my-2 w-full max-w-xs"
+            />
             <p>{u.description}</p>
           </li>
         ))}

--- a/tobis-space/src/pages/Chapter.tsx
+++ b/tobis-space/src/pages/Chapter.tsx
@@ -47,6 +47,7 @@ export default function Chapter() {
         <img
           src={chapter.image}
           alt={chapter.title}
+          loading="lazy"
           className="w-full max-w-md mx-auto"
         />
       )}

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -44,6 +44,7 @@ export default function Drawings() {
         <img
           src={art.image}
           alt={art.name}
+          loading="lazy"
           className="mb-2 h-48 w-48 cursor-pointer object-contain"
           onClick={() => openModal(art)}
         />

--- a/tobis-space/src/pages/DrawingsScrollRoom.tsx
+++ b/tobis-space/src/pages/DrawingsScrollRoom.tsx
@@ -176,6 +176,7 @@ export default function DrawingsScrollRoom() {
                 <img
                   src={item.drawing.image}
                   alt={item.drawing.name}
+                  loading="lazy"
                   className="mb-2 h-60 w-60 cursor-pointer object-contain shadow-lg"
                   onClick={() => openModal(item.drawing)}
                 />


### PR DESCRIPTION
## Summary
- enable native lazy loading for all `<img>` elements

## Testing
- `npm run lint` *(fails: Cannot find module)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686bf4b7f728832392183ea04d8932a6