### PR TITLE
Add payment page and country dropdown

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -9,6 +9,7 @@ import BoardGameUpdates from './pages/BoardGameUpdates'
 import Chapter from './pages/Chapter'
 import CheckoutCancel from './pages/CheckoutCancel'
 import CheckoutSuccess from './pages/CheckoutSuccess'
+import Payment from './pages/Payment'
 import Drawings from './pages/Drawings'
 import DrawingsRoom from './pages/DrawingsRoom'
 import DrawingsScrollRoom from './pages/DrawingsScrollRoom'
@@ -40,6 +41,7 @@ export default function App() {
         <Route path="software" element={<Software />} />
         <Route path="about" element={<About />} />
         <Route path="checkout" element={<Checkout />} />
+        <Route path="payment" element={<Payment />} />
         <Route path="success" element={<CheckoutSuccess />} />
         <Route path="cancel" element={<CheckoutCancel />} />
       </Route>

--- a/tobis-space/src/pages/Checkout.tsx
+++ b/tobis-space/src/pages/Checkout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useCart, type CartItem } from '../contexts/CartContext'
+import { useCart } from '../contexts/CartContext'
 
 interface Address {
   name: string
@@ -10,20 +10,8 @@ interface Address {
   country: string
 }
 
-async function checkout(items: CartItem[], address: Address) {
-  const res = await fetch('/create-checkout-session', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ items, address }),
-  })
-  const data = await res.json()
-  if (data.url) {
-    window.location.href = data.url
-  }
-}
-
 export default function Checkout() {
-  const { items, clear } = useCart()
+  const { items } = useCart()
   const navigate = useNavigate()
   const [address, setAddress] = useState<Address>({
     name: '',
@@ -35,16 +23,16 @@ export default function Checkout() {
 
   if (items.length === 0) return <p>Your cart is empty.</p>
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
     const { name, value } = e.target
     setAddress((a) => ({ ...a, [name]: value }))
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    await checkout(items, address)
-    clear()
-    navigate('/success')
+    navigate('/payment', { state: { address } })
   }
 
   return (
@@ -85,14 +73,20 @@ export default function Checkout() {
         onChange={handleChange}
         className="rounded border p-2 text-black"
       />
-      <input
+      <select
         required
         name="country"
-        placeholder="Country"
         value={address.country}
         onChange={handleChange}
         className="rounded border p-2 text-black"
-      />
+      >
+        <option value="">Select Country</option>
+        <option value="Germany">Germany</option>
+        <option value="United States">United States</option>
+        <option value="United Kingdom">United Kingdom</option>
+        <option value="Canada">Canada</option>
+        <option value="Australia">Australia</option>
+      </select>
       <button type="submit" className="btn bg-green-600 hover:bg-green-700">
         Continue to Payment
       </button>

--- a/tobis-space/src/pages/Payment.tsx
+++ b/tobis-space/src/pages/Payment.tsx
@@ -1,0 +1,59 @@
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useCart, type CartItem } from '../contexts/CartContext'
+
+interface Address {
+  name: string
+  street: string
+  city: string
+  zip: string
+  country: string
+}
+
+async function checkout(items: CartItem[], address: Address) {
+  const res = await fetch('/create-checkout-session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items, address }),
+  })
+  const data = await res.json()
+  if (data.url) {
+    window.location.href = data.url
+  }
+}
+
+export default function Payment() {
+  const { items, clear } = useCart()
+  const navigate = useNavigate()
+  const { state } = useLocation() as { state: { address?: Address } }
+  const address = state?.address
+
+  if (!address) {
+    navigate('/checkout')
+    return null
+  }
+
+  const handlePay = async () => {
+    await checkout(items, address)
+    clear()
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-4">
+      <h2 className="page-title">Payment</h2>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="flex justify-between">
+            <span>{item.name}</span>
+            <span>{item.price.toFixed(2)} €</span>
+          </li>
+        ))}
+      </ul>
+      <div className="font-bold">
+        Total {items.reduce((s, i) => s + i.price, 0).toFixed(2)} €
+      </div>
+      <button onClick={handlePay} className="btn bg-green-600 hover:bg-green-700">
+        Pay Now
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new Payment page for completing the purchase
- update routes to include the payment page
- route Checkout to Payment instead of directly starting the payment
- use a country dropdown on the checkout form

## Testing
- `npm run biome` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bf63f27fc8323aa3335df6a463c1a