### PR TITLE
Add boardgame buy subtab

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -6,6 +6,7 @@ import BoardGameAbout from './pages/BoardGameAbout'
 import BoardGameCommunity from './pages/BoardGameCommunity'
 import BoardGameRules from './pages/BoardGameRules'
 import BoardGameUpdates from './pages/BoardGameUpdates'
+import BoardGameBuy from './pages/BoardGameBuy'
 import Chapter from './pages/Chapter'
 import CheckoutCancel from './pages/CheckoutCancel'
 import CheckoutSuccess from './pages/CheckoutSuccess'
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="community" element={<BoardGameCommunity />} />
           <Route path="rules" element={<BoardGameRules />} />
           <Route path="updates" element={<BoardGameUpdates />} />
+          <Route path="buy" element={<BoardGameBuy />} />
         </Route>
         <Route path="stories" element={<Stories />}>
           <Route index element={<StoryOverview />} />

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -18,6 +18,9 @@ export default function BoardGame() {
         <Link to="updates" className="text-blue-500 underline">
           Updates
         </Link>
+        <Link to="buy" className="text-blue-500 underline">
+          Buy
+        </Link>
       </nav>
       <Outlet />
     </div>

--- a/tobis-space/src/pages/BoardGameBuy.tsx
+++ b/tobis-space/src/pages/BoardGameBuy.tsx
@@ -1,0 +1,36 @@
+import Button from '../components/Button'
+import Card from '../components/Card'
+import { useCart } from '../contexts/CartContext'
+
+export default function BoardGameBuy() {
+  const { items, addItem, removeItem } = useCart()
+  const id = 'boardgame-core'
+  const name = "The Dragon's Tweak"
+  const price = 49.99
+  const inCart = items.some((i) => i.id === id)
+
+  return (
+    <div className="space-y-4">
+      <h3 className="subpage-title">Buy the Game</h3>
+      <Card className="max-w-sm">
+        <div className="space-y-2">
+          <p className="font-semibold">{name}</p>
+          <p>A modular strategy game of summoning dragons.</p>
+          <p className="font-bold">{price.toFixed(2)} €</p>
+          {inCart ? (
+            <Button onClick={() => removeItem(id)} className="bg-red-600 hover:bg-red-700">
+              Remove from Cart
+            </Button>
+          ) : (
+            <Button
+              onClick={() => addItem({ id, name, price })}
+              className="bg-green-600 hover:bg-green-700"
+            >
+              Add to Cart
+            </Button>
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a buy page for the board game
- link to the new subtab from BoardGame navigation
- register the route in `App.tsx`

## Testing
- `npm run biome` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686bf7eddc488323a08b1e8caf544210