### PR TITLE
Resolve type errors in Checkout form

### DIFF
--- a/tobis-space/src/pages/Checkout.tsx
+++ b/tobis-space/src/pages/Checkout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useCart, type CartItem } from '../contexts/CartContext'
+import { useCart } from '../contexts/CartContext'
 import { useTranslation } from '../contexts/LanguageContext'
 
 
@@ -79,14 +79,11 @@ export default function Checkout() {
       <select
         required
         name="country"
-
-        placeholder={t('checkout.country')}
-
         value={address.country}
         onChange={handleChange}
         className="rounded border p-2 text-black"
       >
-        <option value="">Select Country</option>
+        <option value="">{t('checkout.country')}</option>
         <option value="Germany">Germany</option>
         <option value="United States">United States</option>
         <option value="United Kingdom">United Kingdom</option>


### PR DESCRIPTION
## Summary
- clean up unused import in `Checkout.tsx`
- remove invalid placeholder prop on country select

## Testing
- `npm run build` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bf97824f08323b01273a1af9139c2