### PR TITLE
Add validation for checkout address form

### DIFF
--- a/tobis-space/src/i18n/translations.ts
+++ b/tobis-space/src/i18n/translations.ts
@@ -71,6 +71,13 @@ export const translations = {
       empty: 'Your cart is empty.',
       success: 'Thank you for your purchase!',
       cancel: 'Checkout canceled.',
+      errors: {
+        name: 'Please enter your name.',
+        street: 'Please enter your street.',
+        city: 'Please enter your city.',
+        zip: 'ZIP should contain only numbers.',
+        country: 'Please select a country.',
+      },
     },
     cart: {
       empty: 'Your cart is empty.',
@@ -158,6 +165,13 @@ export const translations = {
       empty: 'Dein Warenkorb ist leer.',
       success: 'Vielen Dank für deinen Einkauf!',
       cancel: 'Bezahlung abgebrochen.',
+      errors: {
+        name: 'Bitte Namen eingeben.',
+        street: 'Bitte Straße eingeben.',
+        city: 'Bitte Stadt eingeben.',
+        zip: 'PLZ darf nur Zahlen enthalten.',
+        country: 'Bitte Land auswählen.',
+      },
     },
     cart: {
       empty: 'Dein Warenkorb ist leer.',

--- a/tobis-space/src/pages/Checkout.tsx
+++ b/tobis-space/src/pages/Checkout.tsx
@@ -23,6 +23,7 @@ export default function Checkout() {
     zip: '',
     country: '',
   })
+  const [errors, setErrors] = useState<Partial<Record<keyof Address, string>>>({})
 
   if (items.length === 0) return <p>{t('checkout.empty')}</p>
 
@@ -33,9 +34,22 @@ export default function Checkout() {
     setAddress((a) => ({ ...a, [name]: value }))
   }
 
+  const validate = () => {
+    const errs: Partial<Record<keyof Address, string>> = {}
+    if (!address.name.trim()) errs.name = t('checkout.errors.name')
+    if (!address.street.trim()) errs.street = t('checkout.errors.street')
+    if (!address.city.trim()) errs.city = t('checkout.errors.city')
+    if (!/^\d{4,}$/.test(address.zip.trim())) errs.zip = t('checkout.errors.zip')
+    if (!address.country) errs.country = t('checkout.errors.country')
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    navigate('/payment', { state: { address } })
+    if (validate()) {
+      navigate('/payment', { state: { address } })
+    }
   }
 
   return (
@@ -52,6 +66,7 @@ export default function Checkout() {
         onChange={handleChange}
         className="rounded border p-2 text-black"
       />
+      {errors.name && <p className="text-sm text-red-500">{errors.name}</p>}
       <input
         required
         name="street"
@@ -60,6 +75,7 @@ export default function Checkout() {
         onChange={handleChange}
         className="rounded border p-2 text-black"
       />
+      {errors.street && <p className="text-sm text-red-500">{errors.street}</p>}
       <input
         required
         name="city"
@@ -68,6 +84,7 @@ export default function Checkout() {
         onChange={handleChange}
         className="rounded border p-2 text-black"
       />
+      {errors.city && <p className="text-sm text-red-500">{errors.city}</p>}
       <input
         required
         name="zip"
@@ -76,6 +93,7 @@ export default function Checkout() {
         onChange={handleChange}
         className="rounded border p-2 text-black"
       />
+      {errors.zip && <p className="text-sm text-red-500">{errors.zip}</p>}
       <select
         required
         name="country"
@@ -90,6 +108,7 @@ export default function Checkout() {
         <option value="Canada">Canada</option>
         <option value="Australia">Australia</option>
       </select>
+      {errors.country && <p className="text-sm text-red-500">{errors.country}</p>}
       <button type="submit" className="btn bg-green-600 hover:bg-green-700">
         {t('checkout.continue')}
       </button>


### PR DESCRIPTION
## Summary
- validate address fields in Checkout page
- surface i18n error messages for both English and German

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx biome format src/i18n/translations.ts src/pages/Checkout.tsx --write` *(fails: E403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686bfc3473d88323818a0cdb72d9ac81