### PR TITLE
Add SQLite DB to server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Build a personal homepage where visitors can browse board games, read stories, a
 - **Cart**: Custom React context
 - **Payments**: Stripe Checkout (custom backend)
 - **Backend**: Node.js (Express or serverless)
+- **Database**: SQLite used to store checkout orders
 - **Formatter**: [Biome](https://biomejs.dev)
 
 ## 📂 File Organization

--- a/Agent/backend.md
+++ b/Agent/backend.md
@@ -5,6 +5,7 @@
 - [x] Implement `/create-checkout-session` endpoint
 - [x] Redirect user to Stripe Checkout when clicking "Buy"
 - [x] Handle success/cancel URLs (e.g. `/success`, `/cancel`)
+- [x] Store orders in a local **SQLite** database
 - [ ] (Optional) Add webhook handling for digital delivery
 
 ## Backend Hosting

--- a/tobis-space/package.json
+++ b/tobis-space/package.json
@@ -23,6 +23,7 @@
     "react-markdown": "^9.1.0",
     "react-router-dom": "^6.23.0",
     "stripe": "^14.0.0",
+    "sqlite3": "^5.1.6",
     "three": "^0.177.0"
   },
   "devDependencies": {

--- a/tobis-space/server/index.js
+++ b/tobis-space/server/index.js
@@ -1,8 +1,15 @@
 import express from 'express'
 import Stripe from 'stripe'
 import dotenv from 'dotenv'
+import sqlite3 from 'sqlite3'
 
 dotenv.config()
+
+// Initialize SQLite database to store orders
+const db = new sqlite3.Database('orders.db')
+db.run(
+  'CREATE TABLE IF NOT EXISTS orders (id TEXT PRIMARY KEY, items TEXT, address TEXT)'
+)
 
 const app = express()
 app.use(express.json())
@@ -19,10 +26,26 @@ app.post('/create-checkout-session', async (req, res) => {
       cancel_url: `${req.headers.origin}/cancel`,
       metadata: address,
     })
+    // Persist order details for later processing
+    db.run(
+      'INSERT INTO orders (id, items, address) VALUES (?, ?, ?)',
+      [session.id, JSON.stringify(items), JSON.stringify(address)],
+      (err) => {
+        if (err) console.error('DB insert error:', err)
+      }
+    )
     res.json({ url: session.url })
   } catch (err) {
     res.status(500).json({ error: 'Unable to create session' })
   }
+})
+
+// Simple endpoint to view stored orders
+app.get('/orders', (req, res) => {
+  db.all('SELECT * FROM orders', (err, rows) => {
+    if (err) return res.status(500).json({ error: 'Unable to fetch orders' })
+    res.json(rows)
+  })
 })
 
 const port = process.env.PORT || 3001


### PR DESCRIPTION
## Summary
- integrate SQLite database to record orders
- document new database in project briefing
- track DB setup in backend tasks
- add sqlite3 dependency

## Testing
- `npx biome format tobis-space/server/index.js tobis-space/package.json AGENTS.md Agent/backend.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bfe9cab1c8323927669ea771bab01