### PR TITLE
Fix cart background in dark mode

### DIFF
--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -17,7 +17,7 @@ export default function Cart() {
   if (items.length === 0) return <p>{t('cart.empty')}</p>
 
   return (
-    <div className="p-4 border rounded bg-gray-100">
+    <div className="p-4 border rounded bg-gray-100 dark:bg-gray-700 dark:border-gray-600">
       <ul className="space-y-2">
         {items.map((item) => (
           <li key={item.id} className="flex justify-between">


### PR DESCRIPTION
## Summary
- ensure Cart component uses a dark-mode friendly background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to no internet)*
- `npx biome format tobis-space/src/components/Cart.tsx` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686ca451495c83239d50a7a3ea470e69