### PR TITLE
Add salutation and country list to checkout

### DIFF
--- a/tobis-space/src/i18n/translations.ts
+++ b/tobis-space/src/i18n/translations.ts
@@ -61,6 +61,9 @@ export const translations = {
       email: 'email',
     },
     checkout: {
+      salutation: 'Salutation',
+      mr: 'Mr.',
+      ms: 'Ms.',
       title: 'Checkout',
       name: 'Name',
       street: 'Street',
@@ -72,6 +75,7 @@ export const translations = {
       success: 'Thank you for your purchase!',
       cancel: 'Checkout canceled.',
       errors: {
+        salutation: 'Please select a salutation.',
         name: 'Please enter your name.',
         street: 'Please enter your street.',
         city: 'Please enter your city.',
@@ -155,6 +159,9 @@ export const translations = {
       email: 'E-Mail',
     },
     checkout: {
+      salutation: 'Anrede',
+      mr: 'Herr',
+      ms: 'Frau',
       title: 'Kasse',
       name: 'Name',
       street: 'Straße',
@@ -166,6 +173,7 @@ export const translations = {
       success: 'Vielen Dank für deinen Einkauf!',
       cancel: 'Bezahlung abgebrochen.',
       errors: {
+        salutation: 'Bitte Anrede auswählen.',
         name: 'Bitte Namen eingeben.',
         street: 'Bitte Straße eingeben.',
         city: 'Bitte Stadt eingeben.',

--- a/tobis-space/src/pages/Checkout.tsx
+++ b/tobis-space/src/pages/Checkout.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useCart } from '../contexts/CartContext'
 import { useTranslation } from '../contexts/LanguageContext'
 
 
 interface Address {
+  salutation: string
   name: string
   street: string
   city: string
@@ -17,15 +18,37 @@ export default function Checkout() {
   const navigate = useNavigate()
   const t = useTranslation()
   const [address, setAddress] = useState<Address>({
+    salutation: '',
     name: '',
     street: '',
     city: '',
     zip: '',
     country: '',
   })
+  const [countries, setCountries] = useState<string[]>([])
   const [errors, setErrors] = useState<Partial<Record<keyof Address, string>>>({})
 
   if (items.length === 0) return <p>{t('checkout.empty')}</p>
+
+  useEffect(() => {
+    fetch('/countries')
+      .then((r) => r.json())
+      .then((data) => setCountries(data))
+      .catch(() =>
+        setCountries([
+          'Germany',
+          'United States',
+          'United Kingdom',
+          'Canada',
+          'Australia',
+          'France',
+          'Italy',
+          'Spain',
+          'Switzerland',
+          'Austria',
+        ])
+      )
+  }, [])
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -36,6 +59,7 @@ export default function Checkout() {
 
   const validate = () => {
     const errs: Partial<Record<keyof Address, string>> = {}
+    if (!address.salutation) errs.salutation = t('checkout.errors.salutation')
     if (!address.name.trim()) errs.name = t('checkout.errors.name')
     if (!address.street.trim()) errs.street = t('checkout.errors.street')
     if (!address.city.trim()) errs.city = t('checkout.errors.city')
@@ -58,6 +82,20 @@ export default function Checkout() {
       className="mx-auto flex max-w-md flex-col space-y-4"
     >
       <h2 className="page-title">{t('checkout.title')}</h2>
+      <select
+        required
+        name="salutation"
+        value={address.salutation}
+        onChange={handleChange}
+        className="rounded border p-2 text-black"
+      >
+        <option value="">{t('checkout.salutation')}</option>
+        <option value="mr">{t('checkout.mr')}</option>
+        <option value="ms">{t('checkout.ms')}</option>
+      </select>
+      {errors.salutation && (
+        <p className="text-sm text-red-500">{errors.salutation}</p>
+      )}
       <input
         required
         name="name"
@@ -76,23 +114,25 @@ export default function Checkout() {
         className="rounded border p-2 text-black"
       />
       {errors.street && <p className="text-sm text-red-500">{errors.street}</p>}
-      <input
-        required
-        name="city"
-        placeholder={t('checkout.city')}
-        value={address.city}
-        onChange={handleChange}
-        className="rounded border p-2 text-black"
-      />
+      <div className="flex gap-2">
+        <input
+          required
+          name="city"
+          placeholder={t('checkout.city')}
+          value={address.city}
+          onChange={handleChange}
+          className="w-1/2 rounded border p-2 text-black"
+        />
+        <input
+          required
+          name="zip"
+          placeholder={t('checkout.zip')}
+          value={address.zip}
+          onChange={handleChange}
+          className="w-1/2 rounded border p-2 text-black"
+        />
+      </div>
       {errors.city && <p className="text-sm text-red-500">{errors.city}</p>}
-      <input
-        required
-        name="zip"
-        placeholder={t('checkout.zip')}
-        value={address.zip}
-        onChange={handleChange}
-        className="rounded border p-2 text-black"
-      />
       {errors.zip && <p className="text-sm text-red-500">{errors.zip}</p>}
       <select
         required
@@ -102,11 +142,11 @@ export default function Checkout() {
         className="rounded border p-2 text-black"
       >
         <option value="">{t('checkout.country')}</option>
-        <option value="Germany">Germany</option>
-        <option value="United States">United States</option>
-        <option value="United Kingdom">United Kingdom</option>
-        <option value="Canada">Canada</option>
-        <option value="Australia">Australia</option>
+        {countries.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
       </select>
       {errors.country && <p className="text-sm text-red-500">{errors.country}</p>}
       <button type="submit" className="btn bg-green-600 hover:bg-green-700">


### PR DESCRIPTION
## Summary
- extend i18n for salutation strings and errors
- load available countries from SQLite via new `/countries` endpoint
- add `countries` table on server with default values
- add salutation field in checkout form
- display city and zip on a single line

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx biome format ...` *(fails: 403 Forbidden when downloading package)*

------
https://chatgpt.com/codex/tasks/task_e_686ca4faaca88323b679a74c96dd269c