### PR TITLE
Add quantity to shopping cart

### DIFF
--- a/tobis-space/src/components/Cart.tsx
+++ b/tobis-space/src/components/Cart.tsx
@@ -3,6 +3,8 @@ import {
   faCreditCard,
   faTrash,
   faXmark,
+  faPlus,
+  faMinus,
 } from '@fortawesome/free-solid-svg-icons'
 import { useCart } from '../contexts/CartContext'
 import { useNavigate } from 'react-router-dom'
@@ -10,7 +12,7 @@ import { useTranslation } from '../contexts/LanguageContext'
 
 
 export default function Cart() {
-  const { items, removeItem, clear } = useCart()
+  const { items, addItem, decreaseItem, removeItem, clear } = useCart()
   const navigate = useNavigate()
   const t = useTranslation()
 
@@ -20,9 +22,30 @@ export default function Cart() {
     <div className="p-4 border rounded bg-gray-100 dark:bg-gray-700 dark:border-gray-600">
       <ul className="space-y-2">
         {items.map((item) => (
-          <li key={item.id} className="flex justify-between">
+          <li key={item.id} className="flex items-center justify-between gap-2">
             <span>{item.name}</span>
-            <span>{item.price.toFixed(2)} €</span>
+            {item.multiple ? (
+              <div className="flex items-center gap-1">
+                <button
+                  aria-label="Decrease quantity"
+                  onClick={() => decreaseItem(item.id)}
+                  className="rounded p-1 hover:bg-gray-200 dark:hover:bg-gray-600"
+                >
+                  <FontAwesomeIcon icon={faMinus} />
+                </button>
+                <span>{item.quantity}</span>
+                <button
+                  aria-label="Increase quantity"
+                  onClick={() => addItem(item)}
+                  className="rounded p-1 hover:bg-gray-200 dark:hover:bg-gray-600"
+                >
+                  <FontAwesomeIcon icon={faPlus} />
+                </button>
+              </div>
+            ) : (
+              <span>x{item.quantity}</span>
+            )}
+            <span>{(item.price * item.quantity).toFixed(2)} €</span>
             <button onClick={() => removeItem(item.id)} className="ml-2">
               <FontAwesomeIcon icon={faXmark} />
             </button>
@@ -32,7 +55,11 @@ export default function Cart() {
       <div className="mt-4 flex flex-col space-y-2">
         <div className="flex justify-between">
           <strong>
-            {t('cart.total')} {items.reduce((sum, i) => sum + i.price, 0).toFixed(2)} €
+            {t('cart.total')}{' '}
+            {items
+              .reduce((sum, i) => sum + i.price * i.quantity, 0)
+              .toFixed(2)}{' '}
+            €
           </strong>
           <button onClick={clear} className="ml-2 text-sm text-red-500">
             <FontAwesomeIcon icon={faTrash} className="mr-1" /> {t('cart.clear')}

--- a/tobis-space/src/components/Header.tsx
+++ b/tobis-space/src/components/Header.tsx
@@ -64,7 +64,7 @@ export default function Header({
           </button>
           <button onClick={openCart} className="relative" aria-label="Cart">
             <FontAwesomeIcon icon={faShoppingCart} className="mr-1" />
-            {items.length}
+            {items.reduce((n, i) => n + i.quantity, 0)}
           </button>
           <select
             value={lang}

--- a/tobis-space/src/contexts/CartContext.tsx
+++ b/tobis-space/src/contexts/CartContext.tsx
@@ -5,12 +5,21 @@ export interface CartItem {
   name: string
   price: number
   multiple?: boolean
+  quantity: number
+}
+
+interface CartItemInput {
+  id: string
+  name: string
+  price: number
+  multiple?: boolean
 }
 
 interface CartContextValue {
   items: CartItem[]
-  addItem: (item: CartItem) => void
+  addItem: (item: CartItemInput) => void
   removeItem: (id: string) => void
+  decreaseItem: (id: string) => void
   clear: () => void
 }
 
@@ -19,19 +28,39 @@ const CartContext = createContext<CartContextValue | undefined>(undefined)
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([])
 
-  const addItem = (item: CartItem) =>
+  const addItem = (item: CartItemInput) =>
     setItems((prev) => {
-      if (!item.multiple && prev.some((i) => i.id === item.id)) {
-        return prev
+      const existing = prev.find((i) => i.id === item.id)
+      if (existing) {
+        if (!item.multiple) return prev
+        return prev.map((i) =>
+          i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i,
+        )
       }
-      return [...prev, item]
+      return [...prev, { ...item, quantity: 1 }]
     })
+
+  const decreaseItem = (id: string) =>
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === id)
+      if (!existing) return prev
+      if (existing.quantity <= 1) {
+        return prev.filter((i) => i.id !== id)
+      }
+      return prev.map((i) =>
+        i.id === id ? { ...i, quantity: i.quantity - 1 } : i,
+      )
+    })
+
   const removeItem = (id: string) =>
     setItems((prev) => prev.filter((i) => i.id !== id))
+
   const clear = () => setItems([])
 
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem, clear }}>
+    <CartContext.Provider
+      value={{ items, addItem, decreaseItem, removeItem, clear }}
+    >
       {children}
     </CartContext.Provider>
   )

--- a/tobis-space/src/pages/BoardGameBuy.tsx
+++ b/tobis-space/src/pages/BoardGameBuy.tsx
@@ -7,7 +7,7 @@ export default function BoardGameBuy() {
   const id = 'boardgame-core'
   const name = "The Dragon's Tweak"
   const price = 49.99
-  const count = items.filter((i) => i.id === id).length
+  const count = items.find((i) => i.id === id)?.quantity ?? 0
   const inCart = count > 0
 
   return (


### PR DESCRIPTION
## Summary
- track item quantity in CartContext
- show quantity controls in cart UI
- display total quantity in header icon
- adjust board game page to display quantity

## Testing
- `npm run build` *(fails: Cannot find module 'vite')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ca6914bc48323b375f6fd16176bd6