### PR TITLE
Add animated image stack to home page

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+
+const chapterImages = Object.values(
+  import.meta.glob('../files/chapters/images/*.{png,jpg,jpeg}', {
+    eager: true,
+    import: 'default',
+  }),
+) as string[]
+
+const drawingImages = Object.values(
+  import.meta.glob('../files/drawings/**/*.{jpg,JPG,jpeg,JPEG,png}', {
+    eager: true,
+    import: 'default',
+  }),
+) as string[]
+
+const allImages = [...chapterImages, ...drawingImages]
+
+interface ImgState {
+  id: number
+  src: string
+  angle: number
+  size: number
+  x: number
+  y: number
+}
+
+function randomImage() {
+  return allImages[Math.floor(Math.random() * allImages.length)]
+}
+
+export default function RandomImageStack() {
+  const [images, setImages] = useState<ImgState[]>([])
+
+  useEffect(() => {
+    function addImage() {
+      const angle = (Math.random() - 0.5) * 10
+      const size = 0.9 + Math.random() * 0.2
+      const rad = Math.random() * 2 * Math.PI
+      const distance = 400
+      const id = Date.now() + Math.random()
+      const img: ImgState = {
+        id,
+        src: randomImage(),
+        angle,
+        size,
+        x: Math.cos(rad) * distance,
+        y: Math.sin(rad) * distance,
+      }
+      setImages((prev) => {
+        const next = [...prev, img]
+        if (next.length > 5) next.shift()
+        return next
+      })
+      setTimeout(() => {
+        setImages((prev) =>
+          prev.map((i) =>
+            i.id === id ? { ...i, x: 0, y: 0 } : i,
+          ),
+        )
+      }, 50)
+    }
+
+    addImage()
+    const timer = setInterval(addImage, 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  return (
+    <>
+      {images.map((img) => (
+        <img
+          key={img.id}
+          src={img.src}
+          className="absolute left-1/2 top-1/2 w-64 h-64 object-contain pointer-events-none transition-transform duration-300"
+          style={{
+            transform: `translate(-50%, -50%) translate(${img.x}px, ${img.y}px) rotate(${img.angle}deg) scale(${img.size})`,
+          }}
+        />
+      ))}
+    </>
+  )
+}

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import SineBackground from '../components/SineBackground'
+import RandomImageStack from '../components/RandomImageStack'
 import { useTranslation } from '../contexts/LanguageContext'
 
 export default function Home() {
@@ -6,6 +7,7 @@ export default function Home() {
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-night to-brand-dark text-white text-center">
       <SineBackground />
+      <RandomImageStack />
       <h1 className="relative z-10 text-4xl sm:text-6xl font-bold">
         {t('home.title')}
       </h1>


### PR DESCRIPTION
## Summary
- add `RandomImageStack` component that loads images from chapter and drawing folders
- show `RandomImageStack` on the Home page under the sine background

## Testing
- `npm run build` *(fails: cannot find packages)*
- `npm run lint` *(fails: cannot find ESLint package)*
- `npx biome format .`

------
https://chatgpt.com/codex/tasks/task_e_6870f313dfb08323a35171266b12ba21