### PR TITLE
Fix build by adding tsconfig extends and alias

### DIFF
--- a/tobis-space/tsconfig.app.json
+++ b/tobis-space/tsconfig.app.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",

--- a/tobis-space/tsconfig.node.json
+++ b/tobis-space/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",

--- a/tobis-space/vite.config.ts
+++ b/tobis-space/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { resolve } from 'path'
 
 // Set base path for GitHub Pages when the GITHUB_PAGES env variable is defined
 const base = process.env.GITHUB_PAGES ? '/baseHomePage/' : '/'
@@ -8,4 +9,9 @@ const base = process.env.GITHUB_PAGES ? '/baseHomePage/' : '/'
 export default defineConfig({
   base,
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- ensure tsconfig subprojects extend base config
- configure Vite path alias so `@` resolves

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6871046f7ea88323aaa8db9f1fab671d