### PR TITLE
Update landing page animations

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -14,7 +14,14 @@ const drawingImages = Object.values(
   }),
 ) as string[]
 
-const allImages = [...chapterImages, ...drawingImages]
+const boardgameImages = Object.values(
+  import.meta.glob('../files/boardgame/images/**/*.{jpg,JPG,jpeg,JPEG,png}', {
+    eager: true,
+    import: 'default',
+  }),
+) as string[]
+
+const allImages = [...chapterImages, ...drawingImages, ...boardgameImages]
 
 interface ImgState {
   id: number
@@ -101,10 +108,11 @@ export default function RandomImageStack() {
         <img
           key={img.id}
           src={img.src}
-          className="absolute left-1/2 top-1/2 pointer-events-none transition-all duration-1000 w-[50vmin] h-[50vmin] max-w-[400px] max-h-[400px] object-contain"
+          className="absolute left-1/2 top-1/2 pointer-events-none transition-all duration-1000 w-[50vmin] h-[50vmin] max-w-[400px] max-h-[400px] object-contain transform-gpu"
           style={{
             transform: `translate(-50%, -50%) translate(${img.x}px, ${img.y}px) rotate(${img.angle}deg) scale(${img.leaving ? 0.1 : img.size})`,
             opacity: img.leaving ? 0 : 1,
+            willChange: 'transform, opacity',
           }}
         />
       ))}

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,5 +1,4 @@
-import { useMemo } from 'react'
-import SineBackground from '../components/SineBackground'
+import { useEffect, useState } from 'react'
 import RandomImageStack from '../components/RandomImageStack'
 
 const backgrounds = Object.values(
@@ -10,18 +9,44 @@ const backgrounds = Object.values(
 ) as string[]
 
 export default function Home() {
-  const background = useMemo(
-    () => backgrounds[Math.floor(Math.random() * backgrounds.length)],
-    [],
+  const [index, setIndex] = useState(() =>
+    Math.floor(Math.random() * backgrounds.length),
   )
+  const [fade, setFade] = useState(false)
+
+  useEffect(() => {
+    let startTimer: number
+    let fadeTimer: number
+    function cycle() {
+      startTimer = window.setTimeout(() => {
+        setFade(true)
+        fadeTimer = window.setTimeout(() => {
+          setIndex((i) => (i + 1) % backgrounds.length)
+          setFade(false)
+          cycle()
+        }, 100_000)
+      }, 5_000)
+    }
+    cycle()
+    return () => {
+      clearTimeout(startTimer)
+      clearTimeout(fadeTimer)
+    }
+  }, [])
+
+  const next = (index + 1) % backgrounds.length
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
       <img
-        src={background}
+        src={backgrounds[index]}
         alt="background"
-        className="absolute inset-0 h-full w-full object-cover"
+        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-[100000ms] ${fade ? 'opacity-0' : 'opacity-100'} animate-[spin_120s_linear_infinite]`}
       />
-      <SineBackground />
+      <img
+        src={backgrounds[next]}
+        alt="background"
+        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-[100000ms] ${fade ? 'opacity-100' : 'opacity-0'} animate-[spin_120s_linear_infinite]`}
+      />
       <RandomImageStack />
     </section>
   )


### PR DESCRIPTION
## Summary
- remove blue wave overlay from home page
- add boardgame images for random image stack
- animate stacked images with GPU transforms
- implement rotating, crossfading background images

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687107f1ba40832396e21f554710a459