### PR TITLE
Improve home page background animation

### DIFF
--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,53 +1,51 @@
-import { useEffect, useState } from 'react'
-import RandomImageStack from '../components/RandomImageStack'
+import { useEffect, useState } from "react";
+import RandomImageStack from "../components/RandomImageStack";
 
 const backgrounds = Object.values(
-  import.meta.glob('../files/landing-page/image/*.{png,jpg,jpeg}', {
-    eager: true,
-    import: 'default',
-  }),
-) as string[]
+	import.meta.glob("../files/landing-page/image/*.{png,jpg,jpeg}", {
+		eager: true,
+		import: "default",
+	}),
+) as string[];
 
 export default function Home() {
-  const [index, setIndex] = useState(() =>
-    Math.floor(Math.random() * backgrounds.length),
-  )
-  const [fade, setFade] = useState(false)
+	const [index, setIndex] = useState(() =>
+		Math.floor(Math.random() * backgrounds.length),
+	);
+	const [fade, setFade] = useState(false);
 
-  useEffect(() => {
-    let startTimer: number
-    let fadeTimer: number
-    function cycle() {
-      startTimer = window.setTimeout(() => {
-        setFade(true)
-        fadeTimer = window.setTimeout(() => {
-          setIndex((i) => (i + 1) % backgrounds.length)
-          setFade(false)
-          cycle()
-        }, 100_000)
-      }, 5_000)
-    }
-    cycle()
-    return () => {
-      clearTimeout(startTimer)
-      clearTimeout(fadeTimer)
-    }
-  }, [])
+	useEffect(() => {
+		let fadeTimer: number;
 
-  const next = (index + 1) % backgrounds.length
-  return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
-      <img
-        src={backgrounds[index]}
-        alt="background"
-        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-[100000ms] ${fade ? 'opacity-0' : 'opacity-100'} animate-[spin_120s_linear_infinite]`}
-      />
-      <img
-        src={backgrounds[next]}
-        alt="background"
-        className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-[100000ms] ${fade ? 'opacity-100' : 'opacity-0'} animate-[spin_120s_linear_infinite]`}
-      />
-      <RandomImageStack />
-    </section>
-  )
+		function cycle() {
+			setFade(true);
+			fadeTimer = window.setTimeout(() => {
+				setIndex((i) => (i + 1) % backgrounds.length);
+				setFade(false);
+				cycle();
+			}, 100_000);
+		}
+
+		cycle();
+		return () => {
+			clearTimeout(fadeTimer);
+		};
+	}, []);
+
+	const next = (index + 1) % backgrounds.length;
+	return (
+		<section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
+			<img
+				src={backgrounds[index]}
+				alt="background"
+				className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax] object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-0" : "opacity-100"} animate-spin-zoom`}
+			/>
+			<img
+				src={backgrounds[next]}
+				alt="background"
+				className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax] object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-100" : "opacity-0"} animate-spin-zoom`}
+			/>
+			<RandomImageStack />
+		</section>
+	);
 }

--- a/tobis-space/tailwind.config.js
+++ b/tobis-space/tailwind.config.js
@@ -61,6 +61,16 @@ export default {
 				md: "calc(var(--radius) - 2px)",
 				sm: "calc(var(--radius) - 4px)",
 			},
+			keyframes: {
+				"spin-zoom": {
+					"0%": { transform: "rotate(0deg) scale(1)" },
+					"41.667%": { transform: "rotate(150deg) scale(1.1)" },
+					"100%": { transform: "rotate(360deg) scale(1.1)" },
+				},
+			},
+			animation: {
+				"spin-zoom": "spin-zoom 240s linear infinite",
+			},
 		},
 	},
 	plugins: [require("@tailwindcss/typography"), require("tailwindcss-animate")],


### PR DESCRIPTION
## Summary
- extend tailwind with `spin-zoom` animation
- fade and cycle backgrounds in Home page with continuous 100s fade
- ensure rotating background fills the screen and zooms slowly

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components and other lint errors)*
- `npm run build` *(fails: TypeScript errors in RandomImageStack.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68710c38aee883239a1a88acebf6ce13