### PR TITLE
Add hexagon and token galleries

### DIFF
--- a/tobis-space/src/App.tsx
+++ b/tobis-space/src/App.tsx
@@ -9,6 +9,8 @@ import BoardGameUpdates from "./pages/BoardGameUpdates";
 import BoardGameBuy from "./pages/BoardGameBuy";
 import BoardGameGame from "./pages/BoardGameGame";
 import BoardGameGameCards from "./pages/BoardGameGameCards";
+import BoardGameGameHexagons from "./pages/BoardGameGameHexagons";
+import BoardGameGameTokens from "./pages/BoardGameGameTokens";
 import Chapter from "./pages/Chapter";
 import CheckoutCancel from "./pages/CheckoutCancel";
 import CheckoutSuccess from "./pages/CheckoutSuccess";
@@ -33,10 +35,12 @@ export default function App() {
 					<Route path="community" element={<BoardGameCommunity />} />
 					<Route path="rules" element={<BoardGameRules />} />
 					<Route path="updates" element={<BoardGameUpdates />} />
-					<Route path="game" element={<BoardGameGame />}>
-						<Route index element={<BoardGameGameCards />} />
-						<Route path="cards" element={<BoardGameGameCards />} />
-					</Route>
+                                        <Route path="game" element={<BoardGameGame />}>
+                                                <Route index element={<BoardGameGameCards />} />
+                                                <Route path="cards" element={<BoardGameGameCards />} />
+                                                <Route path="hexagons" element={<BoardGameGameHexagons />} />
+                                                <Route path="tokens" element={<BoardGameGameTokens />} />
+                                        </Route>
 					<Route path="buy" element={<BoardGameBuy />} />
 				</Route>
 				<Route path="stories" element={<Stories />}>

--- a/tobis-space/src/files/boardgame/hexagons.ts
+++ b/tobis-space/src/files/boardgame/hexagons.ts
@@ -1,0 +1,30 @@
+const hexModules = import.meta.glob(
+  "./images/hexagon/*.{png,jpg,jpeg,JPG,JPEG}",
+  {
+    eager: true,
+    import: "default",
+  },
+);
+
+export interface GameHex {
+  id: string;
+  name: string;
+  image: string;
+}
+
+const hexagons: GameHex[] = Object.entries(hexModules)
+  .map(([path, mod]) => {
+    const file = path.split("/").pop() ?? "";
+    const name = file
+      .replace(/\.[^./]+$/, "")
+      .replace(/[_-]/g, " ")
+      .trim();
+    return {
+      id: path,
+      name,
+      image: mod as string,
+    };
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+export default hexagons;

--- a/tobis-space/src/files/boardgame/tokens.ts
+++ b/tobis-space/src/files/boardgame/tokens.ts
@@ -1,0 +1,30 @@
+const tokenModules = import.meta.glob(
+  "./images/tokken/*.{png,jpg,jpeg,JPG,JPEG}",
+  {
+    eager: true,
+    import: "default",
+  },
+);
+
+export interface GameToken {
+  id: string;
+  name: string;
+  image: string;
+}
+
+const tokens: GameToken[] = Object.entries(tokenModules)
+  .map(([path, mod]) => {
+    const file = path.split("/").pop() ?? "";
+    const name = file
+      .replace(/\.[^./]+$/, "")
+      .replace(/[_-]/g, " ")
+      .trim();
+    return {
+      id: path,
+      name,
+      image: mod as string,
+    };
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+export default tokens;

--- a/tobis-space/src/i18n/translations.ts
+++ b/tobis-space/src/i18n/translations.ts
@@ -18,7 +18,9 @@ export const translations = {
 			community: "Community Links",
 			updates: "Game Updates",
 			game: "The Game",
-			cards: "Cards",
+                        cards: "Cards",
+                        hexagons: "Hexagons",
+                        tokens: "Tokens",
 		},
 		drawings: {
 			gallery: "Gallery",
@@ -115,7 +117,9 @@ export const translations = {
 			community: "Community-Links",
 			updates: "Spielupdates",
 			game: "Das Spiel",
-			cards: "Karten",
+                        cards: "Karten",
+                        hexagons: "Hexagone",
+                        tokens: "Marker",
 		},
 		drawings: {
 			gallery: "Galerie",

--- a/tobis-space/src/pages/BoardGameGame.tsx
+++ b/tobis-space/src/pages/BoardGameGame.tsx
@@ -6,11 +6,17 @@ export default function BoardGameGame() {
 	return (
 		<div className="space-y-4">
 			<h3 className="subpage-title">{t("boardgame.game")}</h3>
-			<nav className="flex gap-4">
-				<Link to="cards" className="text-blue-500 underline">
-					{t("boardgame.cards")}
-				</Link>
-			</nav>
+                       <nav className="flex gap-4">
+                               <Link to="cards" className="text-blue-500 underline">
+                                       {t("boardgame.cards")}
+                               </Link>
+                               <Link to="hexagons" className="text-blue-500 underline">
+                                       {t("boardgame.hexagons")}
+                               </Link>
+                               <Link to="tokens" className="text-blue-500 underline">
+                                       {t("boardgame.tokens")}
+                               </Link>
+                       </nav>
 			<Outlet />
 		</div>
 	);

--- a/tobis-space/src/pages/BoardGameGameHexagons.tsx
+++ b/tobis-space/src/pages/BoardGameGameHexagons.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import hexagons from "../files/boardgame/hexagons";
+import { useTranslation } from "../contexts/LanguageContext";
+
+export default function BoardGameGameHexagons() {
+  const t = useTranslation();
+  const [selected, setSelected] = useState<string | null>(null);
+  return (
+    <div className="space-y-4">
+      <h4 className="subpage-title">{t("boardgame.hexagons")}</h4>
+      <div className="flex flex-wrap justify-center gap-4">
+        {hexagons.map((h) => (
+          <img
+            key={h.id}
+            src={h.image}
+            alt={h.name}
+            loading="lazy"
+            className="h-40 w-40 cursor-pointer object-contain"
+            onClick={() => setSelected(h.image)}
+          />
+        ))}
+      </div>
+      {selected && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setSelected(null)}
+        >
+          <img src={selected} alt="hexagon" className="max-h-full max-w-full" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tobis-space/src/pages/BoardGameGameTokens.tsx
+++ b/tobis-space/src/pages/BoardGameGameTokens.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import tokens from "../files/boardgame/tokens";
+import { useTranslation } from "../contexts/LanguageContext";
+
+export default function BoardGameGameTokens() {
+  const t = useTranslation();
+  const [selected, setSelected] = useState<string | null>(null);
+  return (
+    <div className="space-y-4">
+      <h4 className="subpage-title">{t("boardgame.tokens")}</h4>
+      <div className="flex flex-wrap justify-center gap-4">
+        {tokens.map((tok) => (
+          <img
+            key={tok.id}
+            src={tok.image}
+            alt={tok.name}
+            loading="lazy"
+            className="h-24 w-24 cursor-pointer object-contain"
+            onClick={() => setSelected(tok.image)}
+          />
+        ))}
+      </div>
+      {selected && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setSelected(null)}
+        >
+          <img src={selected} alt="token" className="max-h-full max-w-full" />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend board game page to show hexagon and token images
- update translations for new sections
- add hexagon and token data loaders
- wire routes for the new pages

## Testing
- `npx biome@latest format . -w` *(fails: needs interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_68711211f2508323975a6e6939486264