### PR TITLE
Adjust landing page layout

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -78,7 +78,7 @@ export default function RandomImageStack() {
 
   return (
     <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-      <div className="grid grid-cols-1 md:grid-cols-2 md:grid-rows-2 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 md:grid-rows-2 gap-16">
         {stacks.map((stack, index) => (
           <div
             key={index}

--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -35,16 +35,20 @@ export default function Home() {
 	const next = (index + 1) % backgrounds.length;
 	return (
 		<section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
-			<img
-				src={backgrounds[index]}
-				alt="background"
-				className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax] object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-0" : "opacity-100"} animate-spin-zoom`}
-			/>
-			<img
-				src={backgrounds[next]}
-				alt="background"
-				className={`absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax] object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-100" : "opacity-0"} animate-spin-zoom`}
-			/>
+                        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax]">
+                                <img
+                                        src={backgrounds[index]}
+                                        alt="background"
+                                        className={`w-full h-full object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-0" : "opacity-100"} animate-spin-zoom`}
+                                />
+                        </div>
+                        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax]">
+                                <img
+                                        src={backgrounds[next]}
+                                        alt="background"
+                                        className={`w-full h-full object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-100" : "opacity-0"} animate-spin-zoom`}
+                                />
+                        </div>
 			<RandomImageStack />
 		</section>
 	);


### PR DESCRIPTION
## Summary
- spread out the image stacks on the landing page
- keep background images centered while rotating

## Testing
- `npx --yes biome format src/components/RandomImageStack.tsx src/pages/Home.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68711327642483238f1d529c3afdf1c7