### PR TITLE
Add side buttons on home page

### DIFF
--- a/tobis-space/src/pages/Home.tsx
+++ b/tobis-space/src/pages/Home.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import RandomImageStack from "../components/RandomImageStack";
+import { useTranslation } from "../contexts/LanguageContext";
 
 const backgrounds = Object.values(
 	import.meta.glob("../files/landing-page/image/*.{png,jpg,jpeg}", {
@@ -9,9 +11,10 @@ const backgrounds = Object.values(
 ) as string[];
 
 export default function Home() {
-	const [index, setIndex] = useState(() =>
-		Math.floor(Math.random() * backgrounds.length),
-	);
+        const t = useTranslation();
+        const [index, setIndex] = useState(() =>
+                Math.floor(Math.random() * backgrounds.length),
+        );
 	const [fade, setFade] = useState(false);
 
 	useEffect(() => {
@@ -34,7 +37,7 @@ export default function Home() {
 
 	const next = (index + 1) % backgrounds.length;
 	return (
-		<section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
+                <section className="relative min-h-screen flex items-center justify-center overflow-hidden text-white text-center">
                         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[120vmax] h-[120vmax]">
                                 <img
                                         src={backgrounds[index]}
@@ -49,7 +52,41 @@ export default function Home() {
                                         className={`w-full h-full object-cover transition-opacity duration-[100000ms] ${fade ? "opacity-100" : "opacity-0"} animate-spin-zoom`}
                                 />
                         </div>
-			<RandomImageStack />
-		</section>
+                        <div className="absolute inset-y-0 left-0 flex flex-col justify-center items-start gap-4 px-4 z-10">
+                                <Link
+                                        to="/boardgame"
+                                        className="px-4 py-2 rounded border border-gray-300 bg-gray-200/60 text-gray-900 backdrop-blur-md shadow hover:bg-gray-200/80 dark:border-gray-600 dark:bg-gray-700/60 dark:text-gray-100 dark:hover:bg-gray-700/80"
+                                >
+                                        {t('nav.boardgame')}
+                                </Link>
+                                <Link
+                                        to="/stories"
+                                        className="px-4 py-2 rounded border border-gray-300 bg-gray-200/60 text-gray-900 backdrop-blur-md shadow hover:bg-gray-200/80 dark:border-gray-600 dark:bg-gray-700/60 dark:text-gray-100 dark:hover:bg-gray-700/80"
+                                >
+                                        {t('nav.stories')}
+                                </Link>
+                                <Link
+                                        to="/drawings"
+                                        className="px-4 py-2 rounded border border-gray-300 bg-gray-200/60 text-gray-900 backdrop-blur-md shadow hover:bg-gray-200/80 dark:border-gray-600 dark:bg-gray-700/60 dark:text-gray-100 dark:hover:bg-gray-700/80"
+                                >
+                                        {t('nav.drawings')}
+                                </Link>
+                        </div>
+                        <div className="absolute inset-y-0 right-0 flex flex-col justify-center items-end gap-4 px-4 z-10">
+                                <Link
+                                        to="/software"
+                                        className="px-4 py-2 rounded border border-gray-300 bg-gray-200/60 text-gray-900 backdrop-blur-md shadow hover:bg-gray-200/80 dark:border-gray-600 dark:bg-gray-700/60 dark:text-gray-100 dark:hover:bg-gray-700/80"
+                                >
+                                        {t('nav.software')}
+                                </Link>
+                                <Link
+                                        to="/about"
+                                        className="px-4 py-2 rounded border border-gray-300 bg-gray-200/60 text-gray-900 backdrop-blur-md shadow hover:bg-gray-200/80 dark:border-gray-600 dark:bg-gray-700/60 dark:text-gray-100 dark:hover:bg-gray-700/80"
+                                >
+                                        {t('nav.about')}
+                                </Link>
+                        </div>
+                        <RandomImageStack />
+                </section>
 	);
 }


### PR DESCRIPTION
## Summary
- create side navigation on the landing page

## Testing
- `npm run biome` *(fails: found 60 errors)*
- `npm run lint` *(fails: config module missing)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68711964669083239a6ab0a84977fe1c