### PR TITLE
Fix state update typing in RandomImageStack

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -45,8 +45,8 @@ export default function RandomImageStack() {
 
   useEffect(() => {
     function addImages() {
-      setStacks((prev) =>
-        prev.map((stack, index) => {
+      setStacks((prev) => {
+        const nextStacks = prev.map((stack, index) => {
           const id = Date.now() + Math.random()
           const img: ImgState = {
             id,
@@ -59,16 +59,19 @@ export default function RandomImageStack() {
             const first = next[0]
             next[0] = { ...first, leaving: true }
             setTimeout(() => {
-              setStacks((cur) =>
-                cur.map((s, i) =>
-                  i === index ? s.filter((it) => it.id !== first.id) : s,
-                ),
+              setStacks(
+                (cur) =>
+                  cur.map((s, i) =>
+                    i === index ? s.filter((it) => it.id !== first.id) : s,
+                  ) as CornerStacks,
               )
             }, 1000)
           }
           return next
-        }),
-      )
+        }) as CornerStacks
+
+        return nextStacks
+      })
     }
 
     addImages()


### PR DESCRIPTION
## Summary
- keep tuple type when updating state for random image stacks
- cast `setStacks` callback results to `CornerStacks`
- format with Biome

## Testing
- `npx -y biome format src/components/RandomImageStack.tsx`
- `npx -y tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687125d7941c83239496c35fb7736271