### PR TITLE
Add border to home page image stacks

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -94,7 +94,7 @@ export default function RandomImageStack() {
               <img
                 key={img.id}
                 src={img.src}
-                className="absolute inset-0 transition-all duration-1000 object-contain transform-gpu w-full h-full"
+                className="absolute inset-0 transition-all duration-1000 object-contain transform-gpu w-full h-full border border-gray-300 dark:border-gray-600"
                 style={{
                   transform: `rotate(${img.angle}deg) scale(${img.leaving ? 0.1 : img.size})`,
                   opacity: img.leaving ? 0 : 1,


### PR DESCRIPTION
## Summary
- add a subtle border around rotating images on the home page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68713b7ffc1083238b6a0ae0bc52caae