### PR TITLE
Fix home stack image borders

### DIFF
--- a/tobis-space/src/components/RandomImageStack.tsx
+++ b/tobis-space/src/components/RandomImageStack.tsx
@@ -94,7 +94,7 @@ export default function RandomImageStack() {
               <img
                 key={img.id}
                 src={img.src}
-                className="absolute inset-0 transition-all duration-1000 object-contain transform-gpu w-full h-full border border-gray-300 dark:border-gray-600"
+                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transition-all duration-1000 object-contain transform-gpu max-w-full max-h-full border border-gray-300 dark:border-gray-600 shadow"
                 style={{
                   transform: `rotate(${img.angle}deg) scale(${img.leaving ? 0.1 : img.size})`,
                   opacity: img.leaving ? 0 : 1,


### PR DESCRIPTION
## Summary
- adjust RandomImageStack image sizing so the border fits the image
- add a subtle shadow on stack images

## Testing
- `npx -y biome format .`

------
https://chatgpt.com/codex/tasks/task_e_6872478059388323bfeffee251ab689f