### PR TITLE
Add scrolling images per tab

### DIFF
--- a/tobis-space/src/components/ScrollingImage.tsx
+++ b/tobis-space/src/components/ScrollingImage.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+export default function ScrollingImage({ images }: { images: string[] }) {
+  const [src, setSrc] = useState(() => {
+    if (images.length === 0) return "";
+    return images[Math.floor(Math.random() * images.length)];
+  });
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setOffset(window.scrollY * 0.1);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    setSrc(images[Math.floor(Math.random() * images.length)]);
+  }, [images]);
+
+  if (!src) return null;
+
+  return (
+    <img
+      src={src}
+      alt="random"
+      className="fixed bottom-4 left-4 w-32 h-32 object-contain pointer-events-none transition-transform"
+      style={{ transform: `translateX(${offset}px)` }}
+    />
+  );
+}

--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -2,6 +2,14 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom"
 import { useTranslation } from "../contexts/LanguageContext"
 import { Tabs, TabsList, TabsTrigger } from "../components/ui/tabs"
+import ScrollingImage from "../components/ScrollingImage"
+
+const boardgameImages = Object.values(
+  import.meta.glob("../files/boardgame/images/**/*.{png,jpg,jpeg,JPG,JPEG}", {
+    eager: true,
+    import: "default",
+  }),
+) as string[]
 
 export default function BoardGame() {
   const t = useTranslation()
@@ -37,6 +45,7 @@ export default function BoardGame() {
         </TabsList>
       </Tabs>
       <Outlet />
+      <ScrollingImage key={value} images={boardgameImages} />
     </div>
   )
 }

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -7,6 +7,14 @@ import { useCart } from "../contexts/CartContext"
 import { useTranslation } from "../contexts/LanguageContext"
 import drawings, { categories, type Drawing } from "../files/drawings"
 import useDrawingModal from "../hooks/useDrawingModal"
+import ScrollingImage from "../components/ScrollingImage"
+
+const drawingImages = Object.values(
+  import.meta.glob("../files/drawings/**/*.{jpg,JPG,jpeg,JPEG,png}", {
+    eager: true,
+    import: "default",
+  }),
+) as string[]
 
 const allCategory = "all"
 
@@ -101,6 +109,7 @@ export default function Drawings() {
         </div>
       )}
       {modal}
+      <ScrollingImage key={filter} images={drawingImages} />
     </div>
   )
 }

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -1,6 +1,14 @@
 import { Link, Outlet, useLocation, useParams } from "react-router-dom"
 import chapters from "../files/chapters"
 import { useTranslation } from "../contexts/LanguageContext"
+import ScrollingImage from "../components/ScrollingImage"
+
+const storyImages = Object.values(
+  import.meta.glob("../files/chapters/images/*.{png,jpg,jpeg,JPG,JPEG}", {
+    eager: true,
+    import: "default",
+  }),
+) as string[]
 
 export default function Stories() {
   const location = useLocation()
@@ -35,6 +43,10 @@ export default function Stories() {
       </nav>
 
       <Outlet />
+      <ScrollingImage
+        key={isOverview ? 'overview' : detailTarget}
+        images={storyImages}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `ScrollingImage` component that picks a random asset and moves horizontally with scroll
- show a random boardgame image on each board game tab
- show random chapter image on stories page
- show random drawing image on drawings page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883a0698e9083238256adc738bacdbf