### PR TITLE
Fix background image layering

### DIFF
--- a/tobis-space/src/pages/BoardGame.tsx
+++ b/tobis-space/src/pages/BoardGame.tsx
@@ -20,32 +20,34 @@ export default function BoardGame() {
   const value = last === "boardgame" ? "about" : last
 
   return (
-    <div className="space-y-4">
-      <h2 className="page-title">{t("boardgame.title")}</h2>
-      <Tabs value={value} onValueChange={(v) => navigate(v)} className="w-full">
-        <TabsList className="bg-transparent">
-          <TabsTrigger value="about" variant="underline">
-            {t("boardgame.about")}
-          </TabsTrigger>
-          <TabsTrigger value="rules" variant="underline">
-            {t("boardgame.rules")}
-          </TabsTrigger>
-          <TabsTrigger value="community" variant="underline">
-            {t("boardgame.community")}
-          </TabsTrigger>
-          <TabsTrigger value="updates" variant="underline">
-            {t("boardgame.updates")}
-          </TabsTrigger>
-                    <TabsTrigger value="game" variant="underline">
-          		{t("boardgame.game")}
-          </TabsTrigger>
-          <TabsTrigger value="buy" variant="underline">
-            Buy
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
-      <Outlet />
+    <div className="relative">
       <ScrollingImage key={value} images={boardgameImages} />
+      <div className="relative space-y-4 z-10">
+        <h2 className="page-title">{t("boardgame.title")}</h2>
+        <Tabs value={value} onValueChange={(v) => navigate(v)} className="w-full">
+          <TabsList className="bg-transparent">
+            <TabsTrigger value="about" variant="underline">
+              {t("boardgame.about")}
+            </TabsTrigger>
+            <TabsTrigger value="rules" variant="underline">
+              {t("boardgame.rules")}
+            </TabsTrigger>
+            <TabsTrigger value="community" variant="underline">
+              {t("boardgame.community")}
+            </TabsTrigger>
+            <TabsTrigger value="updates" variant="underline">
+              {t("boardgame.updates")}
+            </TabsTrigger>
+            <TabsTrigger value="game" variant="underline">
+              {t("boardgame.game")}
+            </TabsTrigger>
+            <TabsTrigger value="buy" variant="underline">
+              Buy
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <Outlet />
+      </div>
     </div>
   )
 }

--- a/tobis-space/src/pages/Drawings.tsx
+++ b/tobis-space/src/pages/Drawings.tsx
@@ -73,7 +73,9 @@ export default function Drawings() {
   }
 
   return (
-    <div>
+    <div className="relative">
+      <ScrollingImage key={filter} images={drawingImages} />
+      <div className="relative z-10">
       <div className="sticky top-16 z-30 mb-4 flex flex-wrap items-center justify-between gap-2 rounded border border-gray-300 bg-gray-200/70 p-2 backdrop-blur dark:border-gray-600 dark:bg-gray-700/70">
         <div className="flex items-center gap-4">
           <h2 className="page-title m-0">{t('drawings.gallery')}</h2>
@@ -109,7 +111,7 @@ export default function Drawings() {
         </div>
       )}
       {modal}
-      <ScrollingImage key={filter} images={drawingImages} />
+      </div>
     </div>
   )
 }

--- a/tobis-space/src/pages/Stories.tsx
+++ b/tobis-space/src/pages/Stories.tsx
@@ -19,8 +19,13 @@ export default function Stories() {
   const tabClass = (active: boolean) =>
     active ? "border-b-2 border-blue-500" : "text-blue-500"
   return (
-    <div className="space-y-4">
-      <h2 className="page-title">{t('stories.title')}</h2>
+    <div className="relative">
+      <ScrollingImage
+        key={isOverview ? 'overview' : detailTarget}
+        images={storyImages}
+      />
+      <div className="relative space-y-4 z-10">
+        <h2 className="page-title">{t('stories.title')}</h2>
       <p>
         {t('stories.join')} {' '}
         <a
@@ -43,10 +48,7 @@ export default function Stories() {
       </nav>
 
       <Outlet />
-      <ScrollingImage
-        key={isOverview ? 'overview' : detailTarget}
-        images={storyImages}
-      />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ensure tabbed pages position `ScrollingImage` behind content

## Testing
- `npm run lint` *(fails: 10 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6883a9630c1483239ba946103318cfc5